### PR TITLE
back button takes to main screen fix

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/CompletedScene.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/CompletedScene.java
@@ -20,8 +20,16 @@ public class CompletedScene extends Activity {
 				Intent myIntent = new Intent(CompletedScene.this,
 						MapActivity.class);
 				startActivityForResult(myIntent, 0);
+				finish();
 			}
 		});
 	}
-	
+
+	@Override
+	public void onBackPressed() {
+		super.onBackPressed();
+		Intent i = new Intent(CompletedScene.this,MapActivity.class);
+		startActivity(i);
+		finish();
+	}
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -53,6 +53,7 @@ public class MapActivity extends Activity {
 			} else {
 				Intent myIntent = new Intent(MapActivity.this, CompletedScene.class);
 				startActivityForResult(myIntent, 0);
+				finish();
 			}
 		}
 	};


### PR DESCRIPTION
Made changes in Completed Scene class to make the back button take us back to the map instead of going through all the previous screens again.