### PR TITLE
closed db was being accessed, fixed #6

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoom.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoom.java
@@ -173,6 +173,7 @@ public class AvatarRoom extends Activity {
 		continueButton.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
+				getmDbHandler().open();
 				getmDbHandler().setAvatarEye(eye);
 				getmDbHandler().setAvatarFace(face);
 				getmDbHandler().setAvatarHair(hair);


### PR DESCRIPTION
Fixed the crash on selecting a new avatar in AvatarRoom , specifically on pressing the continue button, as a closed database was being accessed. Error Log in image.
![screenshot from 2015-10-22 10 20 41](https://cloud.githubusercontent.com/assets/7212638/10798925/149a800a-7dd0-11e5-8624-928e771ac850.png)
