### PR TITLE
Open map activity after change room

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
@@ -81,7 +81,7 @@ public class AvatarActivity extends Activity {
                     edit.putBoolean(getString(R.string.pref_previously_started), Boolean.TRUE);
                     edit.commit();
                 }
-                Intent myIntent = new Intent(AvatarActivity.this, Game.class);
+                Intent myIntent = new Intent(AvatarActivity.this, MapActivity.class);
 				startActivityForResult(myIntent, 0);
 			}
 		});


### PR DESCRIPTION
Fixed #29 , Map Activity opened after user chooses an avatar