### PR TITLE
Change Room removed from back stack

### DIFF
--- a/PowerUp/app/src/main/AndroidManifest.xml
+++ b/PowerUp/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
         </activity>
         <activity
             android:name="powerup.systers.com.AvatarRoom"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:launchMode="singleInstance">
         </activity>
         <activity
             android:name="powerup.systers.com.AvatarActivity"

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
@@ -83,6 +83,8 @@ public class AvatarActivity extends Activity {
                 }
                 Intent myIntent = new Intent(AvatarActivity.this, MapActivity.class);
 				startActivityForResult(myIntent, 0);
+				AvatarRoom.activityInstance.finish();
+				finish();
 			}
 		});
 	}

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoom.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoom.java
@@ -24,9 +24,11 @@ public class AvatarRoom extends Activity {
 	private Integer hair = 1;
 	private Integer face = 1;
 	private Integer cloth = 1;
+	public static Activity activityInstance;
 
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		activityInstance = this;
 		setmDbHandler(new DatabaseHandler(this));
 		getmDbHandler().open();
 		setContentView(R.layout.avatar_room);


### PR DESCRIPTION
Fixed issue #32 . Change Room activity finishes once the user has completed choosing an avatar and moved to map. If in case she wants to reconsider some aspect, the options screen is maintained in back stack till the process hasn't completed.