### PR TITLE
fixed back to map and navigation issues

### DIFF
--- a/PowerUp/app/src/main/AndroidManifest.xml
+++ b/PowerUp/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         </activity>
         <activity
             android:name="powerup.systers.com.MapActivity"
+            android:launchMode="singleTop"
             android:label="@string/app_name" >
         </activity>
         <activity

--- a/PowerUp/app/src/main/java/powerup/systers/com/CompletedScene.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/CompletedScene.java
@@ -19,6 +19,7 @@ public class CompletedScene extends Activity {
 			public void onClick(View v) {
 				Intent myIntent = new Intent(CompletedScene.this,
 						MapActivity.class);
+				finish();
 				startActivityForResult(myIntent, 0);
 			}
 		});

--- a/PowerUp/app/src/main/java/powerup/systers/com/Game.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/Game.java
@@ -189,6 +189,7 @@ public class Game extends Activity {
 		if (scene.getCompleted() == 1) {
 			if (scene.getNextScenarioID() == -1) {
 				Intent myIntent = new Intent(Game.this, GameOver.class);
+				finish();
 				startActivityForResult(myIntent, 0);
 			} else {
 				SessionHistory.currSessionID = scene.getNextScenarioID();


### PR DESCRIPTION
Fixed #23 . Finished activities to remove them from stack and take back directly to map. Also made map a singleTop launch activity so that multiple instances of the same activity are not launched.