### PR TITLE
Removed change room from back stack

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
@@ -82,6 +82,8 @@ public class AvatarActivity extends Activity {
                     edit.commit();
                 }
                 Intent myIntent = new Intent(AvatarActivity.this, MapActivity.class);
+				AvatarRoom.avatarRoomInstance.finish();
+				finish();
 				startActivityForResult(myIntent, 0);
 			}
 		});

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoom.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoom.java
@@ -25,10 +25,13 @@ public class AvatarRoom extends Activity {
 	private Integer face = 1;
 	private Integer cloth = 1;
 
+	public static Activity avatarRoomInstance;
+
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setmDbHandler(new DatabaseHandler(this));
 		getmDbHandler().open();
+		avatarRoomInstance = this;
 		setContentView(R.layout.avatar_room);
 		eyeView = (ImageView) findViewById(R.id.eyes);
 		faceView = (ImageView) findViewById(R.id.face);


### PR DESCRIPTION
Fixed #32 . The change room has been removed from back stack, avatar room(with options) is maintained while on confirmation screen so that changes can be made till the last moment before moving  on to the map. 