### PR TITLE
Change room opens on start by new user

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/MainActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MainActivity.java
@@ -9,16 +9,13 @@ import android.view.View;
 import android.widget.ImageButton;
 
 public class MainActivity extends Activity {
-
+	private boolean previouslyStarted;
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_main);
 		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
-		boolean previouslyStarted = prefs.getBoolean(getString(R.string.pref_previously_started), false);
-		if (!previouslyStarted) {
-			startActivity(new Intent(MainActivity.this, AvatarRoom.class));
-		}
+		 previouslyStarted = prefs.getBoolean(getString(R.string.pref_previously_started), false);
 		ImageButton new_user = (ImageButton) findViewById(R.id.newUserButtonFirstPage);
 		new_user.setOnClickListener(new View.OnClickListener() {
 			@Override
@@ -33,8 +30,12 @@ public class MainActivity extends Activity {
 		start.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				Intent myIntent = new Intent(MainActivity.this, MapActivity.class);
-				startActivityForResult(myIntent, 0);
+				if (!previouslyStarted) {
+					startActivity(new Intent(MainActivity.this, AvatarRoom.class));
+				}else {
+					Intent myIntent = new Intent(MainActivity.this, MapActivity.class);
+					startActivityForResult(myIntent, 0);
+				}
 			}
 		});
 


### PR DESCRIPTION
@alma-castant Fixed #42 . Main screen opens in either case but change room opens the first time after user presses "start". Please consider this after #45  as that will give a combined effect.