### PR TITLE
Removed Backstack from replay and goToMap buttons.

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -158,6 +158,7 @@ public class GameActivity extends Activity {
 					SessionHistory.totalPoints -= SessionHistory.currScenePoints;
 					goToMap.setClickable(false);
 					Intent myIntent = new Intent(GameActivity.this, MapActivity.class);
+                    myIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 					startActivityForResult(myIntent, 0);
 					getmDbHandler()
 							.setReplayedScenario(scene.getScenarioName());
@@ -176,6 +177,7 @@ public class GameActivity extends Activity {
 					SessionHistory.totalPoints -= SessionHistory.currScenePoints;
 					replay.setClickable(false);
 					Intent myIntent = new Intent(GameActivity.this, GameActivity.class);
+                    myIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 					startActivityForResult(myIntent, 0);
 					getmDbHandler()
 							.setReplayedScenario(scene.getScenarioName());


### PR DESCRIPTION
Clicking on the replay button on the GameActivity.java again started GameActivity.java via an Intent. Thus GameActivity.java was stacked twice and we had to click the back button two times to return to the MapActivity.java. Similarly for goToMap button we had to press back button twice to return to StartActivity.java.

Fixed the problem by popping the stack top with button click.