### PR TITLE
 Corrected the portrait mode for CompletedScene Activity.

### DIFF
--- a/PowerUp/app/src/main/res/layout/completed_scene.xml
+++ b/PowerUp/app/src/main/res/layout/completed_scene.xml
@@ -1,39 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/background" >
-
+    android:background="@drawable/background"
+    android:orientation="vertical"
+    android:gravity="center">
     <TextView
         android:id="@+id/completed_scene_textView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentTop="true"
-        android:layout_marginRight="@dimen/completed_scene_margin_right"
-        android:layout_marginTop="@dimen/completed_scene_margin_top"
-        android:ems="10"
+        android:gravity="center"
+        android:ems="@integer/ems"
         android:text="@string/completed_scene"
         android:textColor="@android:color/black"
-        android:textSize="@dimen/game_text_size" />
-
+        android:textSize="@dimen/game_text_size_final" />
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:layout_marginTop="@dimen/completed_scene_map_margin_top">
     <Button
         android:id="@+id/ContinueButtonMap"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_alignRight="@id/completed_scene_textView"
         android:layout_marginBottom="@dimen/completed_scene_map_margin_bottom"
         android:layout_marginRight="@dimen/completed_scene_map_margin_right"
         android:text="@string/map" />
-
     <Button
         android:id="@+id/store_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignBaseline="@id/ContinueButtonMap"
-        android:layout_alignBottom="@id/ContinueButtonMap"
-        android:layout_alignLeft="@id/completed_scene_textView"
         android:text="@string/store" />
-
-</RelativeLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -37,5 +37,6 @@
     <dimen name="avatar_room_width">80dp</dimen>
     <dimen name="avatar_room_height">80dp</dimen>
     <dimen name="avatar_room_continue_button_land">30dp</dimen>
+    <dimen name= "completed_game_textview">50dp</dimen>
 
 </resources>

--- a/PowerUp/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/PowerUp/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -33,5 +33,6 @@
     <dimen name="avatar_room_width">150dp</dimen>
     <dimen name="avatar_room_height">150dp</dimen>
     <dimen name="avatar_room_continue_button">150dp</dimen>
+    <dimen name="completed_scene_map_margin_bottom">170dp</dimen>
 
 </resources>

--- a/PowerUp/app/src/main/res/values-sw600dp/dimens.xml
+++ b/PowerUp/app/src/main/res/values-sw600dp/dimens.xml
@@ -38,5 +38,9 @@
     <dimen name="avatar_room_width">120dp</dimen>
     <dimen name="avatar_room_height">120dp</dimen>
     <dimen name="avatar_room_continue_button_land">80dp</dimen>
+    <dimen name="completed_game_textview">80dp</dimen>
+    <dimen name="completed_game_width">300dp</dimen>
+    <dimen name="completed_game_height">220dp</dimen>
+    <dimen name="game_text_size_final">30dp</dimen>
 
 </resources>

--- a/PowerUp/app/src/main/res/values-sw720dp-port/dimens.xml
+++ b/PowerUp/app/src/main/res/values-sw720dp-port/dimens.xml
@@ -34,5 +34,6 @@
     <dimen name="avatar_room_width">170dp</dimen>
     <dimen name="avatar_room_height">170dp</dimen>
     <dimen name="avatar_room_continue_button">120dp</dimen>
+    <dimen name="completed_scene_map_margin_bottom">430dp</dimen>
 
 </resources>

--- a/PowerUp/app/src/main/res/values-sw720dp/dimens.xml
+++ b/PowerUp/app/src/main/res/values-sw720dp/dimens.xml
@@ -39,5 +39,9 @@
     <dimen name="avatar_room_width">150dp</dimen>
     <dimen name="avatar_room_height">150dp</dimen>
     <dimen name="avatar_room_continue_button_land">100dp</dimen>
+    <dimen name="completed_game_textview">140dp</dimen>
+    <dimen name="completed_game_width">400dp</dimen>
+    <dimen name="completed_game_height">300dp</dimen>
+    <dimen name="game_text_size_final">40dp</dimen>
 
 </resources>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -52,6 +52,7 @@
     <dimen name="powerup_width">304dp</dimen>
     <dimen name="power_bar_view_height">75dp</dimen>
     <dimen name="game_text_size">20dp</dimen>
+    <dimen name="game_text_size_final">20dp</dimen>
     <dimen name="map_house_click_height">100dp</dimen>
     <dimen name="map_house_click_width">100dp</dimen>
     <dimen name="map_hospital_click_height">100dp</dimen>
@@ -76,5 +77,7 @@
     <item name="map_alpha" type="dimen" format="float">0.00</item>
     <dimen name="avatar_room_margin">50dp</dimen>
     <dimen name="avatar_room_continue_button">50dp</dimen>
+    <dimen name= "completed_game_textview">50dp</dimen>
+    <dimen name="completed_scene_map_margin_top">30dp</dimen>
 
 </resources>

--- a/PowerUp/app/src/main/res/values/integers.xml
+++ b/PowerUp/app/src/main/res/values/integers.xml
@@ -2,4 +2,5 @@
 <resources>
     <integer name="max_progress">100</integer>
     <integer name="half_progress">50</integer>
+    <integer name="ems">9</integer>
 </resources>


### PR DESCRIPTION
The portrait mode for CompletedScene Activity has been corrected to fit all mobile screen sizes and tablets. 
Here is an example on a 4.5" mobile screen.

**Before:**

![screenshot_2016-01-28-03-17-54](https://cloud.githubusercontent.com/assets/8321130/12874944/f57129f6-ce04-11e5-8602-e71ef02e8050.png)

**After:**

![screenshot_2016-01-28-04-36-28](https://cloud.githubusercontent.com/assets/8321130/12874941/e3484566-ce04-11e5-8cdb-4f22d17bea1d.png)
