### PR TITLE
.gitignore modified to match a standard .gitignore

### DIFF
--- a/PowerUp/.gitignore
+++ b/PowerUp/.gitignore
@@ -1,7 +1,33 @@
-.gradle
-/local.properties
-/.idea/workspace.xml
-/.idea/libraries
+#built application files
+*.apk
+*.ap_
+
+# files for the dex VM
+*.dex
+
+# generated files
+bin/
+gen/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Windows thumbnail db
+Thumbs.db
+
+# OSX files
 .DS_Store
-/build
-/captures
+
+# Eclipse project files
+.classpath
+.project
+
+# Android Studio
+*.iml
+.idea
+#.idea/workspace.xml - remove # and delete .idea if it better suit your needs.
+.gradle
+build/
+
+#NDK
+obj/


### PR DESCRIPTION
This modified version of .gitignore is widely accepted and practised.
Source:
http://stackoverflow.com/questions/16736856/what-should-be-in-my-gitignore-for-an-android-studio-project
Fixes issue #130 