### PR TITLE
Add comments and javadoc to existing code

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
@@ -10,9 +10,16 @@ import android.widget.Button;
 import android.widget.ImageView;
 import powerup.systers.com.db.DatabaseHandler;
 
+/**
+ * This screen shows the user their new avatar after they have finished designing it
+ */
 public class AvatarActivity extends Activity {
 
+    /**
+     * A value indicating whether this activity has been started by {@link AvatarRoomActivity}
+     */
     int fromActivity;
+
     private DatabaseHandler mDbHandler;
 
     public void onCreate(Bundle savedInstanceState) {
@@ -32,6 +39,9 @@ public class AvatarActivity extends Activity {
 
         Button continueButton = (Button) findViewById(R.id.continueButton);
         Button backButton = (Button) findViewById(R.id.backButton);
+
+        // Now we display the drawables for the different parts of the body
+
         String eyeImageName =getResources().getString(R.string.eye);
         eyeImageName = eyeImageName + getmDbHandler().getAvatarEye();
         R.drawable ourRID = new R.drawable();
@@ -133,10 +143,12 @@ public class AvatarActivity extends Activity {
         continueButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (fromActivity == 1) {
+                if (fromActivity == 1) { // we've chosen our avatar and confirmed to continue
                     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(AvatarActivity.this);
                     boolean hasPreviouslyStarted = prefs.getBoolean(getString(R.string.preferences_has_previously_started), false);
                     if (!hasPreviouslyStarted) {
+                        // The avatar has been chosen so we have started the game and
+                        // 'has_previously_started' becomes true
                         SharedPreferences.Editor edit = prefs.edit();
                         edit.putBoolean(getString(R.string.preferences_has_previously_started), Boolean.TRUE);
                         edit.apply();

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -1,6 +1,5 @@
 package powerup.systers.com;
 
-
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -13,6 +12,9 @@ import java.util.Random;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 
+/**
+ * Here, the user can choose what their avatar will look like
+ */
 public class AvatarRoomActivity extends Activity {
 
     public static Activity avatarRoomInstance;
@@ -238,6 +240,8 @@ public class AvatarRoomActivity extends Activity {
             @Override
             public void onClick(View v) {
                 getmDbHandler().open();
+
+                // Set and save the chosen avatar features
                 getmDbHandler().setAvatarEye(eye);
                 getmDbHandler().setAvatarFace(face);
                 getmDbHandler().setAvatarHair(hair);
@@ -246,12 +250,14 @@ public class AvatarRoomActivity extends Activity {
                 getmDbHandler().setAvatarGlasses(0);
                 getmDbHandler().setAvatarHat(0);
                 getmDbHandler().setAvatarNecklace(0);
-                getmDbHandler().updateComplete();//set all the complete fields back to 0
-                getmDbHandler().updateReplayed();//set all the replayed fields back to 0
-                SessionHistory.totalPoints=0;    //reset the points stored
+                getmDbHandler().updateComplete(); // set all the complete fields back to 0
+                getmDbHandler().updateReplayed(); // set all the replayed fields back to 0
+                SessionHistory.totalPoints=0; // reset the points stored
                 SessionHistory.currSessionID=1;
                 SessionHistory.currScenePoints=0;
                 getmDbHandler().resetPurchase();
+
+                // Healing, strength, invisibility and telepathy are randomly chosen
                 Random r = new Random();
                 Integer healing = r.nextInt(101 - 1) + 1;
                 getmDbHandler().setHealing(healing);

--- a/PowerUp/app/src/main/java/powerup/systers/com/CompletedSceneActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/CompletedSceneActivity.java
@@ -6,6 +6,11 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
+/**
+ * Shown to the user once they have completed a scene.
+ *
+ * From here, they can go back to the map or to the store.
+ */
 public class CompletedSceneActivity extends Activity {
 
     /**

--- a/PowerUp/app/src/main/java/powerup/systers/com/DressingRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/DressingRoomActivity.java
@@ -11,6 +11,10 @@ import com.akexorcist.roundcornerprogressbar.IconRoundCornerProgressBar;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 
+/**
+ * From this activity, the user can change their clothes, hair and accessories, providing they
+ * have enough Karma points.
+ */
 public class DressingRoomActivity extends AppCompatActivity {
 
     public static Activity dressingRoomInstance;
@@ -29,6 +33,9 @@ public class DressingRoomActivity extends AppCompatActivity {
         ImageView clothView = (ImageView) findViewById(R.id.clothView);
         TextView karmaPoints = (TextView) findViewById(R.id.karmaPoints);
         karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+
+        // Display the avatar features
+
         String eyeImageName = getResources().getString(R.string.eye);
         eyeImageName = eyeImageName + getmDbHandler().getAvatarEye();
         R.drawable ourRID = new R.drawable();

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -20,6 +20,10 @@ import powerup.systers.com.datamodel.Scenario;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 
+/**
+ * The part of the UI responsible for the game, including showing questions and allowing the user
+ * to choose answers
+ */
 @SuppressLint("NewApi")
 public class GameActivity extends Activity {
 
@@ -225,7 +229,7 @@ public class GameActivity extends Activity {
     }
 
     private void updateQA() {
-
+        // Update the questions and answers by modifying the listAdapter
         listAdapter.clear();
         getmDbHandler().getAllAnswer(answers, SessionHistory.currQID);
         for (Answer ans : answers) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
@@ -3,6 +3,9 @@ package powerup.systers.com;
 import android.app.Activity;
 import android.os.Bundle;
 
+/**
+ * Shown to the user after they have completed all of the scenes
+ */
 public class GameOverActivity extends Activity {
 
     /**

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -8,14 +8,21 @@ import android.view.View.OnClickListener;
 import android.widget.Button;
 import powerup.systers.com.db.DatabaseHandler;
 
+/**
+ * The main part of the UI - responsible for displaying the map
+ */
 public class MapActivity extends Activity {
 
     private DatabaseHandler mDbHandler;
+
+    /**
+     * The callback to be invoked when a location on the map has been clicked
+     */
     private OnClickListener onClickListener = new OnClickListener() {
         @Override
         public void onClick(View v) {
             Button b = (Button) v;
-            if (getmDbHandler().setSessionId(b.getText().toString())) {
+            if (getmDbHandler().setSessionId(b.getText().toString())) { // if the scene isn't completed
                 startActivityForResult(new Intent(MapActivity.this, GameActivity.class), 0);
             } else {
                 startActivityForResult(new Intent(MapActivity.this, CompletedSceneActivity.class), 0);
@@ -32,6 +39,8 @@ public class MapActivity extends Activity {
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
         setContentView(R.layout.gamemap);
+
+        // Set OnClickListeners for each of the different locations on the map
 
         Button house = (Button) findViewById(R.id.HouseButton);
         house.setOnClickListener(onClickListener);

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -13,6 +13,12 @@ import com.akexorcist.roundcornerprogressbar.IconRoundCornerProgressBar;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 
+/**
+ * This activity allows the user to decide whether they would like to replay the current scene
+ * after completing it.
+ *
+ * Alternatively they can choose to continue.
+ */
 public class ScenarioOverActivity extends AppCompatActivity {
 
     public static Activity scenarioOverActivityInstance;

--- a/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
@@ -16,6 +16,10 @@ import com.akexorcist.roundcornerprogressbar.IconRoundCornerProgressBar;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 
+/**
+ * This activity can be invoked from {@link DressingRoomActivity} to change one of the avatar
+ * features, such as clothes, hair and accessories.
+ */
 public class SelectFeaturesActivity extends AppCompatActivity {
 
     public static Activity selectFeatureInstance;
@@ -105,7 +109,7 @@ public class SelectFeaturesActivity extends AppCompatActivity {
         powerbarTelepathy.setIconImageResource(R.drawable.icon_telepathy);
         powerbarTelepathy.setProgress(mDbHandler.getTelepathy());
 
-        final String value = getIntent().getExtras().getString(getResources().getString(R.string.feature));
+        final String value = getIntent().getExtras().getString(getResources().getString(R.string.feature)); // the avatar feature we want to change
         Button continueButton = (Button) findViewById(R.id.continueButton);
         final ImageView imageViewSelectFeature = (ImageView) findViewById(R.id.imageViewSelectFeature);
         final TextView tvPaidSelectFeature = (TextView) findViewById(R.id.tvPaidSelectFeature);

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -11,6 +11,10 @@ import android.widget.ImageButton;
 public class StartActivity extends Activity {
 
     private SharedPreferences preferences;
+
+    /**
+     * Indicates whether or not the user has played the game (and chosen their avatar) before
+     */
     private boolean hasPreviouslyStarted;
 
     @Override
@@ -32,6 +36,7 @@ public class StartActivity extends Activity {
             @Override
             public void onClick(View v) {
                 if (hasPreviouslyStarted) {
+                    // We can go straight to the map since the avatar has already been chosen
                     startActivity(new Intent(StartActivity.this, MapActivity.class));
                 } else {
                     startActivity(new Intent(StartActivity.this, AvatarRoomActivity.class));

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Answer.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Answer.java
@@ -1,5 +1,10 @@
 package powerup.systers.com.datamodel;
 
+/**
+ * An object representing an answer in the PowerUp game.
+ *
+ * @see Question
+ */
 public class Answer {
 
     private Integer answerID;

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Question.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Question.java
@@ -1,5 +1,10 @@
 package powerup.systers.com.datamodel;
 
+/**
+ * An object for a question asked in the PowerUp game.
+ *
+ * @see Answer
+ */
 public class Question {
 
     private Integer questionID;

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Scenario.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Scenario.java
@@ -1,5 +1,8 @@
 package powerup.systers.com.datamodel;
 
+/**
+ * Represents a scenario in the PowerUp game
+ */
 public class Scenario {
 
     private int id;

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/SessionHistory.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/SessionHistory.java
@@ -1,5 +1,8 @@
 package powerup.systers.com.datamodel;
 
+/**
+ * A class holding values for the session history including the current session and total points.
+ */
 public class SessionHistory {
     public static int currQID = 1;
     public static int currSessionID = 1;

--- a/PowerUp/app/src/main/java/powerup/systers/com/db/DatabaseHandler.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/db/DatabaseHandler.java
@@ -17,6 +17,9 @@ public class DatabaseHandler extends AbstractDbAdapter {
         ctx.getAssets();
     }
 
+    /**
+     * @return whether or not the game is over (if all scenarios have been completed)
+     */
     public boolean gameOver() {
         String selectQuery = "SELECT  * FROM " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " WHERE " + PowerUpContract.ScenarioEntry.COLUMN_COMPLETED + " = 0";
@@ -28,6 +31,12 @@ public class DatabaseHandler extends AbstractDbAdapter {
         return true;
     }
 
+    /**
+     * Retrieves data from the database in the form of {@link Answer} objects
+     *
+     * @param answers The list to be populated and added to with answers ({@link Answer})
+     * @param qId The question identifier
+     */
     public void getAllAnswer(List<Answer> answers, Integer qId) {
         String selectQuery = "SELECT  * FROM " + PowerUpContract.AnswerEntry.TABLE_NAME +
                 " WHERE " + PowerUpContract.AnswerEntry.COLUMN_QUESTION_ID + " = " + qId;
@@ -47,6 +56,10 @@ public class DatabaseHandler extends AbstractDbAdapter {
         cursor.close();
     }
 
+    /**
+     * @return the current {@link Question}. This is found using the current question identifier
+     *      from {@link SessionHistory}.
+     */
     public Question getCurrentQuestion() {
         String selectQuery = "SELECT  * FROM " + PowerUpContract.QuestionEntry.TABLE_NAME +
                 " WHERE " + PowerUpContract.QuestionEntry.COLUMN_QUESTION_ID + " = "
@@ -63,6 +76,11 @@ public class DatabaseHandler extends AbstractDbAdapter {
         return null;
     }
 
+    /**
+     * @return the current {@link Scenario} using the current session id from {@link SessionHistory}
+     *
+     * @see #getScenarioFromID(int)
+     */
     public Scenario getScenario() {
         String selectQuery = "SELECT  * FROM " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " WHERE " + PowerUpContract.ScenarioEntry.COLUMN_ID + " = "
@@ -85,6 +103,12 @@ public class DatabaseHandler extends AbstractDbAdapter {
         return null;
     }
 
+    /**
+     * @param id The integer identifier of the scenario to return
+     * @return the {@link Scenario} of the specified id
+     *
+     * @see #getScenario()
+     */
     public Scenario getScenarioFromID(int id) {
         String selectQuery = "SELECT  * FROM " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " WHERE " + PowerUpContract.ScenarioEntry.COLUMN_ID + " = "
@@ -107,6 +131,10 @@ public class DatabaseHandler extends AbstractDbAdapter {
         return null;
     }
 
+    /**
+     * @param ScenarioName The name (string) of the {@link Scenario} to modify
+     * @return whether or not the scenario has been found in the database
+     */
     public boolean setSessionId(CharSequence ScenarioName) {
         String selectQuery = "SELECT  * FROM " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " WHERE " + PowerUpContract.ScenarioEntry.COLUMN_SCENARIO_NAME + " = "
@@ -126,6 +154,14 @@ public class DatabaseHandler extends AbstractDbAdapter {
         return false;
     }
 
+    /**
+     * Marks a {@link Scenario} as completed in the database
+     *
+     * @param id The identifier of the {@link Scenario} to be marked as complete
+     *
+     * @see #setCompletedScenario(CharSequence)
+     * @see #updateComplete()
+     */
     public void setCompletedScenario(int id) {
         String updateQuery = "UPDATE  " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " SET " + PowerUpContract.ScenarioEntry.COLUMN_COMPLETED + "=1" +
@@ -141,6 +177,14 @@ public class DatabaseHandler extends AbstractDbAdapter {
         cursor.close();
     }
 
+    /**
+     * Marks a {@link Scenario} as completed in the database using the scenario name
+     *
+     * @param ScenarioName The identifier of the {@link Scenario} to be marked as complete
+     *
+     * @see #setCompletedScenario(int)
+     * @see #updateComplete()
+     */
     public void setCompletedScenario(CharSequence ScenarioName) {
         String updateQuery = "UPDATE  " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " SET " + PowerUpContract.ScenarioEntry.COLUMN_COMPLETED + "=1" +
@@ -149,6 +193,13 @@ public class DatabaseHandler extends AbstractDbAdapter {
         mDb.execSQL(updateQuery);
     }
 
+    /**
+     * Set the {@code replayed} attribute of a {@link Scenario} to {@code 1} (true)
+     *
+     * @param ScenarioName The name of the {@link Scenario} to be modified
+     *
+     * @see #updateReplayed()
+     */
     public void setReplayedScenario(CharSequence ScenarioName) {
         String updateQuery = "UPDATE  " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " SET " + PowerUpContract.ScenarioEntry.COLUMN_REPLAYED + "=1" +
@@ -461,21 +512,37 @@ public class DatabaseHandler extends AbstractDbAdapter {
         mDb.execSQL(query);
     }
 
-    public void updateComplete()
-    {
+    /**
+     * Set the {@code complete} attribute of a {@link Scenario} to 0 (false)
+     *
+     * @see #setCompletedScenario(int)
+     * @see #setCompletedScenario(CharSequence)
+     */
+    public void updateComplete() {
         String query = "UPDATE " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " SET " + PowerUpContract.ScenarioEntry.COLUMN_COMPLETED + " = 0";
         mDb.execSQL(query);
     }
 
-    public void updateReplayed()
-    {
+    /**
+     * Set the {@code replayed} attribute of a {@link Scenario} to 0 (false)
+     *
+     * @see #setReplayedScenario(CharSequence)
+     */
+    public void updateReplayed() {
         String query = "UPDATE " + PowerUpContract.ScenarioEntry.TABLE_NAME +
                 " SET " + PowerUpContract.ScenarioEntry.COLUMN_REPLAYED + " = 0";
         mDb.execSQL(query);
     }
-    public void resetPurchase()
-    {
+
+    /**
+     * Reset any purchases that have been made for clothes, hair and accessories.
+     *
+     * @see #setPurchasedClothes(int)
+     * @see #setPurchasedHair(int)
+     * @see #setPurchasedAccessories(int)
+     */
+    public void resetPurchase() {
         String query = "UPDATE " + PowerUpContract.ClothesEntry.TABLE_NAME +
                 " SET " + PowerUpContract.ClothesEntry.COLUMN_PURCHASED + " = 0";
         mDb.execSQL(query);


### PR DESCRIPTION
I've added comments in the format you requested (from the blog post [here](http://www.hongkiat.com/blog/source-code-comment-styling-tips/)) and javadoc on methods and classes using the standard coding style for javadoc (including using tags such as `@see` and `@param` where necessary).

I have decided not to add comments on parts of the code that are obvious, where commenting would be unnecessary and make the code look messy - for example, it is obvious to understand what `setInvisibility(Integer)` in `DatabaseHandler` does because of its method name.

Please do let me know, however, if there are any parts of this pull request you would like modified - I would be more than happy to make the changes and commit for a re-review.