### PR TITLE
Landscape UI issues solved

### DIFF
--- a/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
@@ -7,6 +7,8 @@
     android:background="@drawable/background"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="powerup.systers.com.ScenarioOverActivity">
 
     <RelativeLayout
@@ -144,35 +146,35 @@
 
     <TextView
         android:id="@+id/scenarioTextView"
-        android:layout_width="@dimen/scenario_tv_width"
-        android:layout_height="@dimen/scenario_tv_height"
-        android:layout_marginTop="@dimen/scenario_description_margin_top"
+        android:layout_width="@dimen/scenario_text_land_width"
+        android:layout_height="@dimen/scenario_text_land_height"
+        android:layout_centerVertical="true"
         android:layout_toEndOf="@+id/relativeLayout3"
         android:layout_toRightOf="@+id/relativeLayout3"
-        android:text="@string/scenario_description"
+        android:text="Scenario description"
         android:textColor="@color/powerup_black"
         android:textSize="@dimen/back_button_textsize" />
 
     <Button
         android:id="@+id/replayButton"
-        android:layout_width="@dimen/button_layout_width"
+        android:layout_width="@dimen/linear_layout_width"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/health_text_ImageView"
-        android:layout_marginLeft="@dimen/margin_left_replay_button"
-        android:layout_toRightOf="@+id/relativeLayout3"
+        android:layout_toRightOf="@id/scenarioTextView"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"
         android:background="@drawable/brown_button_background"
         android:text="@string/replay"
         android:textAllCaps="false"
-        android:textSize="@dimen/button_font" />
+        android:textSize="@dimen/button_font"
+        />
 
     <Button
         android:id="@+id/continueButton"
-        android:layout_width="@dimen/button_layout_width"
+        android:layout_width="@dimen/linear_layout_width"
         android:layout_height="wrap_content"
         android:layout_alignTop="@+id/replayButton"
         android:layout_toEndOf="@+id/replayButton"
         android:layout_toRightOf="@+id/replayButton"
-        android:layout_marginLeft="@dimen/continue_button_margin_left"
         android:background="@drawable/brown_button_background"
         android:text="@string/continue_text"
         android:textAllCaps="false"
@@ -180,18 +182,17 @@
 
     <ImageView
         android:id="@+id/karmaImageView"
-        android:layout_width="@dimen/karma_iv_width"
-        android:layout_height="@dimen/karma_iv_height"
-        android:layout_marginTop="@dimen/karma_imageview_margin_top"
+        android:layout_width="@dimen/karma_image_width"
+        android:layout_height="@dimen/karma_image_height"
         android:src="@drawable/karma_box" />
 
     <TextView
         android:id="@+id/karmaPoints"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/scenario_tv_margin"
-        android:layout_marginTop="@dimen/scenario_tv_margin"
-        android:hint="@string/points"
+        android:layout_marginLeft="@dimen/karma_points_marginLeft"
+        android:layout_marginTop="@dimen/karma_point_marginTop"
+        android:hint="points"
         android:textColor="@color/powerup_black"
         android:textSize="@dimen/back_button_textsize" />
 

--- a/PowerUp/app/src/main/res/layout-land/avatar.xml
+++ b/PowerUp/app/src/main/res/layout-land/avatar.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/background"
     android:orientation="vertical">
 
+<RelativeLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
     <ImageView
         android:id="@+id/faceView"
         android:layout_width="@dimen/face_view_width"
@@ -26,7 +30,7 @@
         android:id="@+id/hairView"
         android:layout_width="@dimen/hair_view_width"
         android:layout_height="@dimen/hair_view_height"
-        android:layout_alignTop="@+id/faceView"
+        android:layout_marginTop="@dimen/avatar_hair_marginTop"
         android:layout_centerHorizontal="true"
         android:src="@drawable/hair1" />
 
@@ -34,9 +38,8 @@
         android:id="@+id/clothView"
         android:layout_width="@dimen/cloth_view_width"
         android:layout_height="@dimen/cloth_view_height"
-        android:layout_alignParentBottom="true"
+        android:layout_alignTop="@id/eyeView"
         android:layout_centerHorizontal="true"
-        android:layout_marginTop="@dimen/avatar_cloth_view_land_margin_top"
         android:src="@drawable/cloth1" />
 
     <ImageView
@@ -102,3 +105,4 @@
         android:textSize="@dimen/back_button_textsize" />
 
 </RelativeLayout>
+</ScrollView>

--- a/PowerUp/app/src/main/res/layout-land/game_activity.xml
+++ b/PowerUp/app/src/main/res/layout-land/game_activity.xml
@@ -26,9 +26,9 @@
     <ListView
         android:id="@+id/mainListView"
         android:layout_width="@dimen/gameActivity_lv_width"
-        android:layout_height="@dimen/main_list_view_height"
         android:layout_below="@+id/questionView"
         android:layout_centerHorizontal="true"
+        android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:background="@android:color/white"
         android:clickable="true" />
@@ -63,7 +63,6 @@
         android:layout_width="@dimen/questionview_tv_width"
         android:layout_height="wrap_content"
         android:layout_below="@+id/scenarioNameEditText"
-        android:layout_toRightOf="@+id/faceImageView"
         android:layout_centerHorizontal="true"
         android:background="@android:color/transparent"
         android:ems="@integer/text_view_ems"

--- a/PowerUp/app/src/main/res/layout-land/game_activity.xml
+++ b/PowerUp/app/src/main/res/layout-land/game_activity.xml
@@ -70,7 +70,10 @@
         android:layout_marginTop="@dimen/questionview_tv_margin_top"
         android:hint="@string/question"
         android:textColor="#4e4d40"
-        android:textSize="@dimen/game_text_size" />
+        android:textSize="@dimen/game_text_size"
+        android:layout_toLeftOf="@id/askerImageView"
+        android:layout_marginBottom="@dimen/question_marginBottom"
+        android:layout_toEndOf="@+id/relativeLayout" />
 
     <RelativeLayout
         android:id="@+id/relativeLayout"

--- a/PowerUp/app/src/main/res/layout/pgame.xml
+++ b/PowerUp/app/src/main/res/layout/pgame.xml
@@ -26,7 +26,7 @@
     <ListView
         android:id="@+id/mainListView"
         android:layout_width="@dimen/main_list_view_width"
-        android:layout_height="@dimen/main_list_view_height"
+        android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_below="@+id/askerImageView"
         android:background="@android:color/white"

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -184,4 +184,5 @@
     <dimen name="karma_points_marginLeft">20dp</dimen>
     <dimen name="karma_point_marginTop">20dp</dimen>
     <dimen name="health_power_bar_margin_right">20dp</dimen>
+    <dimen name="question_marginBottom">10dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -67,7 +67,6 @@
     <dimen name="map_boyfriend_click_height">100dp</dimen>
     <dimen name="map_boyfriend_click_width">75dp</dimen>
     <dimen name="main_list_view_width">200dp</dimen>
-    <dimen name="main_list_view_height">200dp</dimen>
     <dimen name="question_view_margin_top">40dp</dimen>
     <dimen name="question_view_width">200dp</dimen>
     <dimen name="redo_button_width">30dp</dimen>
@@ -175,6 +174,14 @@
     <dimen name="continue_button_margin_left">30dp</dimen>
     <dimen name="scenario_description_margin_top">40dp</dimen>
     <dimen name="karma_imageview_margin_top">5dp</dimen>
-    <dimen name="health_power_bar_margin_right">20dp</dimen>
     <dimen name="scenarioNameEditText_margin_top">-4dp</dimen>
+    <dimen name="avatar_hair_marginTop">95dp</dimen>
+    <dimen name="replay_button_height">45dp</dimen>
+    <dimen name="scenario_text_land_width">150dp</dimen>
+    <dimen name="scenario_text_land_height">80dp</dimen>
+    <dimen name="karma_image_width">80dp</dimen>
+    <dimen name="karma_image_height">50dp</dimen>
+    <dimen name="karma_points_marginLeft">20dp</dimen>
+    <dimen name="karma_point_marginTop">20dp</dimen>
+    <dimen name="health_power_bar_margin_right">20dp</dimen>
 </resources>


### PR DESCRIPTION
#275
The following issues have been resolved -
1. The avatar was not proper in some dpi screens - I have added scrollview for small screens like Nexus one and some rectification are made to make avatar properly work on different dpi screens.
2. Replay and continue buttons were placed below the question and thus couldn't fit in landscape mode. Now the button are placed to the right of question so it can fit in landscape. Thus, a new landscape xml is created - activity_scenario_over.xml
3. White box below the conversion has been removed by making listview as wrap_content.

Please review. :-)
 