### PR TITLE
Fix: Changed start button to resume during gameplay

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -9,6 +9,7 @@ package powerup.systers.com;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.Typeface;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.View;
@@ -18,6 +19,9 @@ public class StartActivity extends Activity {
 
     private SharedPreferences preferences;
     private boolean hasPreviouslyStarted;
+    private Button startButton;
+    private Button newUserButton;
+    private Button aboutButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -25,7 +29,7 @@ public class StartActivity extends Activity {
         setContentView(R.layout.activity_main);
         preferences = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
         hasPreviouslyStarted = preferences.getBoolean(getString(R.string.preferences_has_previously_started), false);
-        Button newUserButton = (Button) findViewById(R.id.newUserButtonFirstPage);
+        newUserButton = (Button) findViewById(R.id.newUserButtonFirstPage);
         newUserButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -33,7 +37,7 @@ public class StartActivity extends Activity {
             }
         });
 
-        Button startButton = (Button) findViewById(R.id.startButtonMain);
+        startButton = (Button) findViewById(R.id.startButtonMain);
         startButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -46,7 +50,7 @@ public class StartActivity extends Activity {
             }
         });
 
-        Button aboutButton = (Button) findViewById(R.id.aboutButtonMain);
+        aboutButton = (Button) findViewById(R.id.aboutButtonMain);
         aboutButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -60,5 +64,8 @@ public class StartActivity extends Activity {
     protected void onResume() {
         super.onResume();
         hasPreviouslyStarted = preferences.getBoolean(getString(R.string.preferences_has_previously_started), false);
+        if (hasPreviouslyStarted) {
+            startButton.setText(getString(R.string.resume_text));
+        }
     }
 }

--- a/PowerUp/app/src/main/res/layout/activity_main.xml
+++ b/PowerUp/app/src/main/res/layout/activity_main.xml
@@ -9,7 +9,7 @@
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context="com.example.powerup.MainActivity">
+    tools:context="powerup.systers.com.StartActivity">
 
     <TextView
         android:id="@+id/powerupTextView"
@@ -35,7 +35,8 @@
         android:layout_height="@dimen/start_button_height"
         android:background="@drawable/brown_button_background"
         android:text="@string/start_text"
-        android:textSize="@dimen/button_font"/>
+        android:textSize="@dimen/button_font"
+        android:textStyle="bold" />
 
     <Button
         android:id="@+id/newUserButtonFirstPage"
@@ -43,7 +44,7 @@
         android:layout_height="@dimen/new_user_button_height"
         android:background="@drawable/brown_button_background"
         android:text="@string/new_user_text"
-        android:textSize="@dimen/button_font"/>
+        android:textSize="@dimen/button_font" />
 
     <Button
         android:id="@+id/aboutButtonMain"
@@ -51,6 +52,6 @@
         android:layout_height="@dimen/about_button_height"
         android:background="@drawable/brown_button_background"
         android:text="@string/about_text"
-        android:textSize="@dimen/button_font"/>
+        android:textSize="@dimen/button_font" />
 
 </LinearLayout>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="about_how_app_helps_section_title"><![CDATA[> How does PowerUp help teenagers?]]></string>
     <string name="about_how_app_helps_section_content">The app uses Social and Emotional Learning (SEL) to empower middle school girls to take ownership of their health and sexual activity. It is designed to increase access to reproductive health and self-esteem education by incorporating quality and relevant information surrounding those topics and it helps concretize corresponding concepts through interactive activities. The Content is based on SEL Core Competencies (Self-awareness, Self-management, Social awareness, Relationship skills, Decision making).</string>
     <string name="new_user_text"><b>New User</b></string>
+    <string name="resume_text">Resume</string>
     <string name="start_text"><b>Start</b></string>
     <string name="about_text"><b>About</b></string>
     <string name="continue_text"><b>Continue</b></string>


### PR DESCRIPTION
PR for #279 
![image](https://cloud.githubusercontent.com/assets/15179401/22173482/f39aba54-dfea-11e6-9f53-473a7ada8294.png)

For the above change I made the following changes:
- added resume text in strings.xml.

- set`android:textStyle="bold"`to bold in activity_main.xml

- used `boolean hasPreviouslyStarted` to determine weather gameplay has started or not.