### PR TITLE
Fix Orientation Issues in About and Game Activity

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AboutActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AboutActivity.java
@@ -7,40 +7,75 @@ import android.widget.TextView;
 
 public class AboutActivity extends Activity {
 
+    private boolean isAboutGameOpen = false;
+    private boolean isAboutUrgencyOpen = false;
+    private boolean isAboutHelpingOpen = false;
+    private static String isGameOpen = "ABOUT_GAME_OPEN";
+    private static String isUrgencyOpen = "ABOUT_URGENCY_OPEN";
+    private static String isHelpingOpen = "ABOUT_HELPING_OPEN";
+    private TextView aboutGameSection, aboutUrgencySection, aboutHelpingSection;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_about);
-    }
+        if (savedInstanceState != null){
+            isAboutGameOpen = savedInstanceState.getBoolean(isGameOpen);
+            isAboutUrgencyOpen = savedInstanceState.getBoolean(isUrgencyOpen);
+            isAboutHelpingOpen = savedInstanceState.getBoolean(isHelpingOpen);
+        }
+        aboutGameSection = (TextView) findViewById(R.id.about_the_game);
+        aboutUrgencySection = (TextView) findViewById(R.id.about_the_urgency);
+        aboutHelpingSection = (TextView) findViewById(R.id.about_helping_by);
+        if (isAboutGameOpen){
+           aboutGameSection.setVisibility(View.VISIBLE);
+        }
+        if (isAboutUrgencyOpen){
+            aboutUrgencySection.setVisibility(View.VISIBLE);
+        }
+        if (isAboutHelpingOpen){
+            aboutHelpingSection.setVisibility(View.VISIBLE);
+        }
 
+    }
     public void aboutGamePressed(View view){
-        TextView section = (TextView) findViewById(R.id.about_the_game);
-        if(section.getVisibility() == View.GONE){
-            section.setVisibility(View.VISIBLE);
+        if (aboutGameSection.getVisibility() == View.GONE){
+            aboutGameSection.setVisibility(View.VISIBLE);
+            isAboutGameOpen = true;
         } else {
-            section.setVisibility(View.GONE);
+            aboutGameSection.setVisibility(View.GONE);
+            isAboutGameOpen = false;
         }
     }
 
     public void aboutUrgencyPressed(View view){
-        TextView section = (TextView) findViewById(R.id.about_the_urgency);
-        if(section.getVisibility() == View.GONE){
-            section.setVisibility(View.VISIBLE);
+        if (aboutUrgencySection.getVisibility() == View.GONE){
+            aboutUrgencySection.setVisibility(View.VISIBLE);
+            isAboutUrgencyOpen = true;
         } else {
-            section.setVisibility(View.GONE);
+            aboutUrgencySection.setVisibility(View.GONE);
+            isAboutUrgencyOpen = false;
         }
     }
 
     public void aboutHelpingByPressed(View view){
-        TextView section = (TextView) findViewById(R.id.about_helping_by);
-        if(section.getVisibility() == View.GONE){
-            section.setVisibility(View.VISIBLE);
+        if (aboutHelpingSection.getVisibility() == View.GONE){
+            aboutHelpingSection.setVisibility(View.VISIBLE);
+            isAboutHelpingOpen = true;
         } else {
-            section.setVisibility(View.GONE);
+            aboutHelpingSection.setVisibility(View.GONE);
+            isAboutHelpingOpen = false;
         }
     }
 
     public void pressHomeButton(View view){
         finish();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(isGameOpen,isAboutGameOpen);
+        outState.putBoolean(isHelpingOpen,isAboutHelpingOpen);
+        outState.putBoolean(isUrgencyOpen,isAboutUrgencyOpen);
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -38,9 +38,13 @@ public class GameActivity extends Activity {
     private Button replay;
     private Button goToMap;
     private ArrayAdapter<String> listAdapter;
+    private static boolean isStateChanged = false;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        if(savedInstanceState != null){
+            isStateChanged = true;
+        }
         super.onCreate(savedInstanceState);
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
@@ -228,7 +232,11 @@ public class GameActivity extends Activity {
                 startActivity(intent);
             }
         }
-        SessionHistory.currQID = scene.getFirstQuestionID();
+        if (isStateChanged == false){
+            SessionHistory.currQID = scene.getFirstQuestionID();
+        } else {
+            isStateChanged = false;
+        }
         scenarioNameTextView.setText(scene.getScenarioName());
         updateQA();
     }


### PR DESCRIPTION
Fixes #282 
@chhavip @aanchal07 @anubhakushwaha Changes made are as follows -

1. For About Activity - Added boolean variables isAboutGameOpen, isAboutUrgencyOpen and  isAboutHelpingOpen which will retain the state of Textview in saveInstanceState. 
Other than this, Textview needed to be made global so as to access them in onCreate().

2. For Game Activity - If the orientation is changed, activity is recreated and savedInstanceState is not null. Thus in this case, we can keep the question same as last question in SessionHistory.

Please review. Thanks :-)