### PR TITLE
Fix Multiple Bugs in Karma Points System in Store

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/DressingRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/DressingRoomActivity.java
@@ -19,6 +19,7 @@ public class DressingRoomActivity extends AppCompatActivity {
 
     public static Activity dressingRoomInstance;
     private DatabaseHandler mDbHandler;
+    private TextView karmaPoints;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -31,7 +32,7 @@ public class DressingRoomActivity extends AppCompatActivity {
         ImageView faceView = (ImageView) findViewById(R.id.faceView);
         ImageView hairView = (ImageView) findViewById(R.id.hairView);
         ImageView clothView = (ImageView) findViewById(R.id.clothView);
-        TextView karmaPoints = (TextView) findViewById(R.id.karmaPoints);
+        karmaPoints = (TextView) findViewById(R.id.karmaPoints);
         karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
         String eyeImageName = getResources().getString(R.string.eye);
         eyeImageName = eyeImageName + getmDbHandler().getAvatarEye();
@@ -130,5 +131,10 @@ public class DressingRoomActivity extends AppCompatActivity {
 
     public void setmDbHandler(DatabaseHandler mDbHandler) {
         this.mDbHandler = mDbHandler;
+    }
+    @Override
+    protected void onResume() {
+        super.onResume();
+        karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
@@ -566,7 +566,7 @@ public class SelectFeaturesActivity extends AppCompatActivity {
                     else {
                         getmDbHandler().setAvatarHair(hair);
                         getmDbHandler().setPurchasedHair(hair);
-                        SessionHistory.totalPoints = SessionHistory.totalPoints - getmDbHandler().getPointsClothes(cloth);
+                        SessionHistory.totalPoints = SessionHistory.totalPoints - getmDbHandler().getPointsHair(hair);
                     }
                 } else if (value.equalsIgnoreCase(getResources().getString(R.string.accessory))) {
                     if (hatPurchased != 0) {
@@ -582,7 +582,7 @@ public class SelectFeaturesActivity extends AppCompatActivity {
                         if (SessionHistory.totalPoints < getmDbHandler().getPointsAccessories(glassesPurchased))
                             Toast.makeText(SelectFeaturesActivity.this, R.string.points_check, Toast.LENGTH_SHORT).show();
                         else {
-                            SessionHistory.totalPoints = SessionHistory.totalPoints - getmDbHandler().getPointsAccessories(hatPurchased);
+                            SessionHistory.totalPoints = SessionHistory.totalPoints - getmDbHandler().getPointsAccessories(glassesPurchased);
                             getmDbHandler().setPurchasedAccessories(glassesPurchased);
                             getmDbHandler().setAvatarGlasses(glasses);
                         }
@@ -591,7 +591,7 @@ public class SelectFeaturesActivity extends AppCompatActivity {
                         if (SessionHistory.totalPoints < getmDbHandler().getPointsAccessories(bagPurchased))
                             Toast.makeText(SelectFeaturesActivity.this, R.string.points_check, Toast.LENGTH_SHORT).show();
                         else {
-                            SessionHistory.totalPoints = SessionHistory.totalPoints - getmDbHandler().getPointsAccessories(hatPurchased);
+                            SessionHistory.totalPoints = SessionHistory.totalPoints - getmDbHandler().getPointsAccessories(bagPurchased);
                             getmDbHandler().setPurchasedAccessories(bagPurchased);
                             getmDbHandler().setAvatarBag(bag);
                         }
@@ -600,7 +600,7 @@ public class SelectFeaturesActivity extends AppCompatActivity {
                         if (SessionHistory.totalPoints < getmDbHandler().getPointsAccessories(necklacePurchased))
                             Toast.makeText(SelectFeaturesActivity.this, R.string.points_check, Toast.LENGTH_SHORT).show();
                         else {
-                            SessionHistory.totalPoints = SessionHistory.totalPoints - getmDbHandler().getPointsAccessories(hatPurchased);
+                            SessionHistory.totalPoints = SessionHistory.totalPoints - getmDbHandler().getPointsAccessories(necklacePurchased);
                             getmDbHandler().setPurchasedAccessories(necklacePurchased);
                             getmDbHandler().setAvatarNecklace(necklace);
                         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
@@ -608,7 +608,9 @@ public class SelectFeaturesActivity extends AppCompatActivity {
                 }
                 Intent intent = new Intent(SelectFeaturesActivity.this, AvatarActivity.class);
                 intent.putExtra(getResources().getString(R.string.feature), 2);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);
+                finish();
                 getmDbHandler().close();
             }
         });


### PR DESCRIPTION
Fixes #281 
Bugs solved - 

1. As shown below, earlier on pressing back in final avatar screen, user can go back to selection screen - I have solved this by taking user to main screen on pressing back thereby restricting to reedit the selection. (Using Intent.FLAG_ACTIVITY_CLEAR_TOP)

<img src="https://cloud.githubusercontent.com/assets/13872065/22085174/f30d78a4-ddf8-11e6-95dc-48162deebab3.gif" height="400" width="200"> => After => <img src="https://cloud.githubusercontent.com/assets/13872065/22616603/01d91606-ead6-11e6-818f-ef8afc9d0eac.gif" height="400" width="200">

2. Above, as we can see points were not updated on pressing back because - After pressing back control enters onResume of activity and shows old score on even Main Screen. I have solved this by updating score in onResume.

3. For Hair, Bag, Glasses, and Necklace, the points deducted were always wrong. I have solved this by rectifying some mistakes. (Earlier it was deducting points of clothes for Hair AND Points of Hat for Bag/Glasses/Necklace)

<img src="https://cloud.githubusercontent.com/assets/13872065/22616368/c38be4e0-ead1-11e6-9de4-d9569bcfa6cc.jpeg" height="400" width="200">

4. Sometimes the Karma score went negative though should not be allowed as shown above. This problem was also solved once I figured out above.

@chhavip @anubhakushwaha @aanchal07 Please review. Thanks :-)