### PR TITLE
Added Support For Android 7.1 (Changed targetSdkVersion to 25)

### DIFF
--- a/PowerUp/app/build.gradle
+++ b/PowerUp/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "powerup.systers.com.powerup"
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -21,6 +21,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:25.1.1'
     compile 'com.akexorcist:RoundCornerProgressBar:2.0.3'
 }

--- a/PowerUp/build.gradle
+++ b/PowerUp/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/PowerUp/gradle/wrapper/gradle-wrapper.properties
+++ b/PowerUp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 24 10:14:11 CEST 2015
+#Mon Feb 06 02:21:10 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
Changed  compileSdkVersion to 25
and   targetSdkVersion to 25
also,
app build.gradle was using 
buildToolsVersion "23.0.1" 
and dependency 'com.android.support:appcompat-v7:23.0.1' . 
This commit updates both of them with 
buildToolsVersion "23.0.2" 
and dependency 'com.android.support:appcompat-v7:25.1.1'
