### PR TITLE
Fixes#332:HomeButton in ScneraioOverActivity is not aligned properly

### DIFF
--- a/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
@@ -182,15 +182,15 @@
         android:id="@+id/karmaImageView"
         android:layout_width="@dimen/karma_iv_width"
         android:layout_height="@dimen/karma_iv_height"
-        android:layout_marginTop="@dimen/karma_imageview_margin_top"
+        android:layout_marginTop="@dimen/karmaimageview_margin_top"
         android:src="@drawable/karma_box" />
 
     <TextView
         android:id="@+id/karmaPoints"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/scenario_tv_margin"
-        android:layout_marginTop="@dimen/scenario_tv_margin"
+        android:layout_marginLeft="@dimen/scenario_tv_margin_left"
+        android:layout_marginTop="@dimen/scenario_tv_margin_top"
         android:hint="@string/points"
         android:textColor="@color/powerup_black"
         android:textSize="@dimen/back_button_textsize" />

--- a/PowerUp/app/src/main/res/layout/activity_scenario_over.xml
+++ b/PowerUp/app/src/main/res/layout/activity_scenario_over.xml
@@ -7,8 +7,6 @@
     android:background="@drawable/background"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="powerup.systers.com.ScenarioOverActivity">
 
     <RelativeLayout
@@ -64,6 +62,7 @@
         android:layout_height="wrap_content"
         android:layout_above="@+id/power_bar"
         android:layout_alignParentEnd="true"
+        android:layout_marginRight="@dimen/health_text_ImageView_margin_right"
         android:layout_alignParentRight="true"
         android:src="@drawable/health_power_text" />
 
@@ -170,6 +169,7 @@
         android:id="@+id/continueButton"
         android:layout_width="@dimen/button_layout_width"
         android:layout_height="wrap_content"
+        android:layout_marginRight="@dimen/continuebutton_margin_right"
         android:layout_alignTop="@+id/replayButton"
         android:layout_toEndOf="@+id/replayButton"
         android:layout_toRightOf="@+id/replayButton"
@@ -182,14 +182,15 @@
         android:id="@+id/karmaImageView"
         android:layout_width="@dimen/karma_iv_width"
         android:layout_height="@dimen/karma_iv_height"
+        android:layout_marginTop="@dimen/karmaimageview_margin_top"
         android:src="@drawable/karma_box" />
 
     <TextView
         android:id="@+id/karmaPoints"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/scenario_tv_margin"
-        android:layout_marginTop="@dimen/scenario_tv_margin"
+        android:layout_marginLeft="@dimen/scenario_tv_margin_left"
+        android:layout_marginTop="@dimen/scenario_tv_margin_top"
         android:hint="@string/points"
         android:textColor="@color/powerup_black"
         android:textSize="@dimen/back_button_textsize" />

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -146,7 +146,8 @@
     <dimen name="scenario_ib_height">45dp</dimen>
     <dimen name="karma_iv_width">80dp</dimen>
     <dimen name="karma_iv_height">50dp</dimen>
-    <dimen name="scenario_tv_margin">20dp</dimen>
+    <dimen name="scenario_tv_margin_left">15dp</dimen>
+    <dimen name="scenario_tv_margin_top">36dp</dimen>
     <dimen name="avatar_hair_iv_margin">180dp</dimen>
     <dimen name="gameActivity_ll_margin_left">40dp</dimen>
     <dimen name="gamemap_homeButton_width">50dp</dimen>
@@ -174,7 +175,9 @@
     <dimen name="store_map_button_text_size">18sp</dimen>
     <dimen name="continue_button_margin_left">30dp</dimen>
     <dimen name="scenario_description_margin_top">40dp</dimen>
-    <dimen name="karma_imageview_margin_top">5dp</dimen>
     <dimen name="health_power_bar_margin_right">20dp</dimen>
     <dimen name="scenarioNameEditText_margin_top">-4dp</dimen>
+    <dimen name="karmaimageview_margin_top">16dp</dimen>
+    <dimen name="continuebutton_margin_right">16dp</dimen>
+    <dimen name="health_text_ImageView_margin_right">16dp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #332 
Now the position of **HomeButton**  icon in ScneraioOverActivity remains intact at the extreme right
even on different screen sizes.
**ScreenShot**
![device-2017-02-17-113238](https://cloud.githubusercontent.com/assets/18090596/23054905/a99e81b4-f508-11e6-87f2-42518dd4eb95.png)

@chhavip @anubhakushwaha @aanchal07 Please review the PR.
_Thank you_