### PR TITLE
Fixes#312:Overdraw in many activities in an application

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AboutActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AboutActivity.java
@@ -18,6 +18,7 @@ public class AboutActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_about);
+        getWindow().setBackgroundDrawable(null);
         if (savedInstanceState != null){
             isAboutGameOpen = savedInstanceState.getBoolean(isGameOpen);
             isAboutUrgencyOpen = savedInstanceState.getBoolean(isUrgencyOpen);

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarActivity.java
@@ -23,6 +23,7 @@ public class AvatarActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.avatar);
+        getWindow().setBackgroundDrawable(null);
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
         fromActivity = getIntent().getExtras().getInt(getResources().getString(R.string.from_activity));

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -41,6 +41,7 @@ public class AvatarRoomActivity extends Activity {
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
         setContentView(R.layout.avatar_room);
+        getWindow().setBackgroundDrawable(null);
         eyeView = (ImageView) findViewById(R.id.eyes);
         faceView = (ImageView) findViewById(R.id.face);
         clothView = (ImageView) findViewById(R.id.clothes);

--- a/PowerUp/app/src/main/java/powerup/systers/com/CompletedSceneActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/CompletedSceneActivity.java
@@ -20,6 +20,7 @@ public class CompletedSceneActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.completed_scene);
+        getWindow().setBackgroundDrawable(null);
         Button backToMap = (Button) findViewById(R.id.ContinueButtonMap);
         backToMap.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/PowerUp/app/src/main/java/powerup/systers/com/DressingRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/DressingRoomActivity.java
@@ -27,6 +27,7 @@ public class DressingRoomActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.dressing_room);
+        getWindow().setBackgroundDrawable(null);
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
         ImageView eyeView = (ImageView) findViewById(R.id.eyeView);

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -52,6 +52,8 @@ public class GameActivity extends Activity {
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
         setContentView(R.layout.game_activity);
+        getWindow().setBackgroundDrawable(null);
+        gameActivityInstance = this;
         // Find the ListView resource.
         ListView mainListView = (ListView) findViewById(R.id.mainListView);
         questionTextView = (TextView) findViewById(R.id.questionView);

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
@@ -17,5 +17,6 @@ public class GameOverActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.completed_game);
+        getWindow().setBackgroundDrawable(null);
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -34,6 +34,8 @@ public class ScenarioOverActivity extends AppCompatActivity {
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
         setContentView(R.layout.activity_scenario_over);
+        getWindow().setBackgroundDrawable(null);
+        scenarioOverActivityInstance = this;
         scenarioActivityDone = 1;
         Button replayButton = (Button) findViewById(R.id.replayButton);
         Button continueButton = (Button) findViewById(R.id.continueButton);

--- a/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
@@ -43,6 +43,7 @@ public class SelectFeaturesActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_select_features);
+        getWindow().setBackgroundDrawable(null);
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
         LinearLayout linearLayout = (LinearLayout) findViewById(R.id.linearLayout);

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -27,6 +27,7 @@ public class StartActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        getWindow().setBackgroundDrawable(null);
         preferences = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
         hasPreviouslyStarted = preferences.getBoolean(getString(R.string.preferences_has_previously_started), false);
         newUserButton = (Button) findViewById(R.id.newUserButtonFirstPage);


### PR DESCRIPTION
Fixes #312 

**Fix**
Removed unneeded backgrounds in different layouts(portrait & landscape) in all activities as suggested in the link given below:
[http://stackoverflow.com/questions/13906917/overdraw-and-romain-guys-blog-post-android-performance-case-study](http://stackoverflow.com/questions/13906917/overdraw-and-romain-guys-blog-post-android-performance-case-study)

And after removing the overdrawn I have checked all the activities with the help of **Debug GPU Overdraw Walkthrough** in developer option in mobile phone as suggested in the [developers.android](https://developer.android.com/studio/profile/dev-options-overdraw.html) article.

For Reference:-
**Before Overdrawn**
![device-2017-02-25-162325](https://cloud.githubusercontent.com/assets/18090596/23330712/0c6d2c82-fb7b-11e6-97bc-5d096675ac7a.png)
**After Removing Overdrawn**
![device-2017-02-25-162552](https://cloud.githubusercontent.com/assets/18090596/23330713/10b34420-fb7b-11e6-9a6a-e10dcdf0bd4f.png)

@chhavip @anubhakushwaha @aanchal07  Please review this PR . :)
_Thank you_