### PR TITLE
Added support for all screen sizes for Dressing Room

### DIFF
--- a/PowerUp/app/src/main/res/layout-land/avatar.xml
+++ b/PowerUp/app/src/main/res/layout-land/avatar.xml
@@ -72,12 +72,15 @@
 
     <Button
         android:id="@+id/continueButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/back_button_width"
+        android:layout_height="@dimen/back_button_height"
         android:layout_alignTop="@+id/backButton"
         android:layout_toEndOf="@+id/hairView"
         android:layout_toRightOf="@+id/hairView"
-        android:background="@drawable/brown_button_background" />
+        android:background="@drawable/brown_button_background"
+        android:text="@string/continue_text"
+        android:textAllCaps="false"
+        android:textSize="@dimen/back_button_textsize"/>
 
     <TextView
         android:id="@+id/finalAvatarTextViewLand"
@@ -87,7 +90,7 @@
         android:layout_marginTop="@dimen/avatar_margin"
         android:text="@string/avatar_land"
         android:textColor="@color/powerup_black"
-        android:textSize="@dimen/final_avatar_text_view_text_size" />
+        android:textSize="@dimen/final_avatar_text_size" />
 
     <Button
         android:id="@+id/backButton"

--- a/PowerUp/app/src/main/res/layout-land/avatar_room.xml
+++ b/PowerUp/app/src/main/res/layout-land/avatar_room.xml
@@ -226,11 +226,12 @@
 
     <Button
         android:id="@+id/continueButtonAvatar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/back_button_width"
+        android:layout_height="@dimen/back_button_height"
         android:layout_alignBottom="@+id/relativeLayoutAvatar"
         android:layout_alignEnd="@+id/linearLayout5"
         android:layout_alignRight="@+id/linearLayout5"
-        android:background="@drawable/brown_button_background" />
+        android:background="@drawable/brown_button_background"
+        android:text="@string/continue_text"/>
 
 </RelativeLayout>

--- a/PowerUp/app/src/main/res/layout/activity_select_features.xml
+++ b/PowerUp/app/src/main/res/layout/activity_select_features.xml
@@ -171,154 +171,186 @@
                 android:src="@drawable/ic_keyboard_arrow_right_white_18dp" />
         </LinearLayout>
     </LinearLayout>
+<LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:id="@+id/main_linear_layout"
+    android:layout_toRightOf="@id/relativeLayout2"
+    android:layout_above="@id/power_bar"
+    android:layout_marginLeft="@dimen/relative2_marginLeft"
 
+  >
     <LinearLayout
-        android:id="@+id/linearLayouthandbag"
-        android:layout_width="@dimen/select_feature_linear_layout_width"
-        android:layout_height="@dimen/select_feature_linear_layout_height"
-        android:layout_marginTop="@dimen/select_feature_linear_layout_margin_top"
-        android:layout_toEndOf="@+id/relativeLayout2"
-        android:layout_toRightOf="@+id/relativeLayout2"
-        android:background="@drawable/round_rect_green_shape"
-        android:gravity="center"
-        android:orientation="vertical">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/bag"
-            android:textAllCaps="true"
-            android:textColor="@color/powerup_black"
-            android:textSize="@dimen/final_avatar_text_view_text_size" />
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/select_feature_image_height">
-
-            <ImageView
-                android:id="@+id/imageViewhandbag"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:src="@drawable/bag1" />
-
-            <TextView
-                android:id="@+id/tvPaidHandbag"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/select_feature_tv_paid_left_margin_small"
-                android:layout_marginTop="@dimen/select_feature_tv_paid_top_margin_small"
-                android:rotation="@integer/text_view_rotation"
-                android:textColor="@color/powerup_black"
-                android:textSize="@dimen/select_feature_tv_paid_size_small" />
-
-        </RelativeLayout>
-
-        <TextView
-            android:id="@+id/tvHandbagPoints"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:textSize="@dimen/text_view_necklace" />
+        android:id="@+id/horizontal_holder"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_alignParentRight="true"
+        android:layout_marginRight="@dimen/horizontal_holder_marginRight"
+        android:layout_weight="3"
+        android:layout_marginTop="@dimen/horizontal_holder_marginTop">
 
         <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:id="@+id/linearLayouthandbag"
+            android:layout_width="@dimen/select_feature_linear_layout_width"
+            android:layout_height="@dimen/select_feature_linear_layout_height"
+            android:layout_weight="1"
+            android:layout_marginRight="20dp"
+            android:layout_toEndOf="@+id/relativeLayout2"
+            android:layout_toRightOf="@+id/relativeLayout2"
+            android:background="@drawable/round_rect_green_shape"
             android:gravity="center"
-            android:orientation="horizontal">
-
-            <ImageButton
-                android:id="@+id/leftHandbag"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_keyboard_arrow_left_white_18dp" />
-
-            <ImageButton
-                android:id="@+id/rightHandbag"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_keyboard_arrow_right_white_18dp" />
-        </LinearLayout>
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/linearLayoutGlasses"
-        android:layout_width="@dimen/select_feature_linear_layout_width"
-        android:layout_height="@dimen/select_feature_linear_layout_height"
-        android:layout_alignTop="@+id/linearLayouthandbag"
-        android:layout_marginLeft="@dimen/select_feature_linear_layout_margin_left"
-        android:layout_toRightOf="@+id/linearLayouthandbag"
-        android:background="@drawable/round_rect_blue_shape"
-        android:gravity="center"
-        android:orientation="vertical">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/glasses"
-            android:textAllCaps="true"
-            android:textColor="@color/powerup_black"
-            android:textSize="@dimen/final_avatar_text_view_text_size" />
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/select_feature_image_height">
-
-            <ImageView
-                android:id="@+id/imageViewGlasses"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/select_feature_image_height"
-                android:src="@drawable/glasses1" />
+            android:orientation="vertical">
 
             <TextView
-                android:id="@+id/tvPaidGlasses"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/select_feature_tv_paid_left_margin_small"
-                android:layout_marginTop="@dimen/select_feature_tv_paid_top_margin_small"
-                android:rotation="@integer/text_view_rotation"
+                android:gravity="center"
+                android:text="@string/bag"
+                android:textAllCaps="true"
                 android:textColor="@color/powerup_black"
-                android:textSize="@dimen/select_feature_tv_paid_size_small" />
-        </RelativeLayout>
+                android:textSize="@dimen/final_avatar_text_view_text_size" />
 
-        <TextView
-            android:id="@+id/tvGlassesPoints"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:textSize="@dimen/text_view_necklace" />
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/select_feature_image_height">
+
+                <ImageView
+                    android:id="@+id/imageViewhandbag"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/bag1" />
+
+                <TextView
+                    android:id="@+id/tvPaidHandbag"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/select_feature_tv_paid_left_margin_small"
+                    android:layout_marginTop="@dimen/select_feature_tv_paid_top_margin_small"
+                    android:rotation="@integer/text_view_rotation"
+                    android:textColor="@color/powerup_black"
+                    android:textSize="@dimen/select_feature_tv_paid_size_small" />
+
+            </RelativeLayout>
+
+            <TextView
+                android:id="@+id/tvHandbagPoints"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:textSize="@dimen/text_view_necklace" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal">
+                <ImageButton
+                    android:id="@+id/leftHandbag"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:src="@drawable/ic_keyboard_arrow_left_white_18dp" />
+
+                <ImageButton
+                    android:id="@+id/rightHandbag"
+                    android:layout_weight="1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_keyboard_arrow_right_white_18dp" />
+            </LinearLayout>
+        </LinearLayout>
 
         <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:id="@+id/linearLayoutGlasses"
+            android:layout_width="@dimen/select_feature_linear_layout_width"
+            android:layout_height="@dimen/select_feature_linear_layout_height"
+            android:layout_alignTop="@+id/linearLayouthandbag"
+            android:layout_weight="1"
+            android:layout_toRightOf="@+id/linearLayouthandbag"
+            android:background="@drawable/round_rect_blue_shape"
             android:gravity="center"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
-            <ImageButton
-                android:id="@+id/leftGlasses"
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/ic_keyboard_arrow_left_white_18dp" />
+                android:gravity="center"
+                android:text="@string/glasses"
+                android:textAllCaps="true"
+                android:textColor="@color/powerup_black"
+                android:textSize="@dimen/final_avatar_text_view_text_size" />
 
-            <ImageButton
-                android:id="@+id/rightGlasses"
-                android:layout_width="wrap_content"
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/select_feature_image_height">
+
+                <ImageView
+                    android:id="@+id/imageViewGlasses"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/select_feature_image_height"
+                    android:src="@drawable/glasses1" />
+
+                <TextView
+                    android:id="@+id/tvPaidGlasses"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/select_feature_tv_paid_left_margin_small"
+                    android:layout_marginTop="@dimen/select_feature_tv_paid_top_margin_small"
+                    android:rotation="@integer/text_view_rotation"
+                    android:textColor="@color/powerup_black"
+                    android:textSize="@dimen/select_feature_tv_paid_size_small" />
+            </RelativeLayout>
+
+            <TextView
+                android:id="@+id/tvGlassesPoints"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:src="@drawable/ic_keyboard_arrow_right_white_18dp" />
+                android:gravity="center"
+                android:textSize="@dimen/text_view_necklace" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <ImageButton
+                    android:id="@+id/leftGlasses"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:src="@drawable/ic_keyboard_arrow_left_white_18dp" />
+
+                <ImageButton
+                    android:id="@+id/rightGlasses"
+                    android:layout_weight="1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_keyboard_arrow_right_white_18dp" />
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
-
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:id="@+id/horizontal_holder2"
+        android:layout_weight="3"
+        android:layout_below="@id/horizontal_holder"
+        android:layout_alignParentRight="true"
+        android:layout_marginRight="@dimen/horizontal_holder_marginRight">
     <LinearLayout
         android:id="@+id/linearLayoutHat"
         android:layout_width="@dimen/select_feature_linear_layout_width"
+        android:layout_weight="1"
         android:layout_height="@dimen/select_feature_linear_layout_height"
         android:layout_alignLeft="@+id/linearLayouthandbag"
         android:layout_below="@+id/linearLayouthandbag"
         android:layout_marginTop="@dimen/select_feature_linear_layout_margin_top"
         android:background="@drawable/round_rect_pink_shape"
         android:gravity="center"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:layout_marginRight="@dimen/hat_marginRight">
 
         <TextView
             android:layout_width="wrap_content"
@@ -367,10 +399,12 @@
                 android:id="@+id/leftHat"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/ic_keyboard_arrow_left_white_18dp" />
+                android:src="@drawable/ic_keyboard_arrow_left_white_18dp"
+                android:layout_weight="1"/>
 
             <ImageButton
                 android:id="@+id/rightHat"
+                android:layout_weight="1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:src="@drawable/ic_keyboard_arrow_right_white_18dp" />
@@ -386,6 +420,7 @@
         android:layout_marginTop="@dimen/select_feature_linear_layout_margin_top"
         android:background="@drawable/round_rect_purple_shape"
         android:gravity="center"
+        android:layout_weight="1"
         android:orientation="vertical">
 
         <TextView
@@ -435,22 +470,39 @@
             <ImageButton
                 android:id="@+id/leftNecklace"
                 android:layout_width="wrap_content"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
                 android:src="@drawable/ic_keyboard_arrow_left_white_18dp" />
 
             <ImageButton
                 android:id="@+id/rightNecklace"
+                android:layout_weight="1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:src="@drawable/ic_keyboard_arrow_right_white_18dp" />
         </LinearLayout>
     </LinearLayout>
+    </LinearLayout>
+    <Button
+        android:id="@+id/continueButton"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_above="@+id/power_bar"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:background="@drawable/brown_button_background"
+        android:text="@string/continue_text"
+        android:textAllCaps="false"
+        android:layout_weight="1"
+        android:textSize="@dimen/button_font"/>
 
+</LinearLayout>
     <RelativeLayout
         android:id="@+id/power_bar"
         android:layout_width="match_parent"
         android:layout_height="@dimen/power_bar_view_height"
-        android:layout_alignParentBottom="true">
+        android:layout_alignParentBottom="true"
+        >
 
         <ImageView
             android:id="@+id/powerBarView"
@@ -523,16 +575,5 @@
 
     </RelativeLayout>
 
-    <Button
-        android:id="@+id/continueButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/power_bar"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:background="@drawable/brown_button_background"
-        android:text="@string/continue_text"
-        android:textAllCaps="false"
-        android:textSize="@dimen/button_font"/>
 
 </RelativeLayout>

--- a/PowerUp/app/src/main/res/layout/avatar.xml
+++ b/PowerUp/app/src/main/res/layout/avatar.xml
@@ -91,7 +91,7 @@
         android:gravity="center"
         android:text="@string/avatar"
         android:textColor="@color/powerup_black"
-        android:textSize="@dimen/final_avatar_text_view_text_size" />
+        android:textSize="@dimen/final_avatar_text_size" />
 
     <Button
         android:id="@+id/backButton"

--- a/PowerUp/app/src/main/res/values-large/dimens.xml
+++ b/PowerUp/app/src/main/res/values-large/dimens.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+
+    <dimen name="face_view_width">100dp</dimen>
+    <dimen name="face_view_height">120dp</dimen>
+    <dimen name="eye_view_width">50dp</dimen>
+    <dimen name="eye_view_height">50dp</dimen>
+    <dimen name="eye_view_margin_bottom">30dp</dimen>
+    <dimen name="hair_view_width">150dp</dimen>
+    <dimen name="hair_view_height">150dp</dimen>
+    <dimen name="cloth_view_width">75dp</dimen>
+    <dimen name="cloth_view_height">200dp</dimen>
+    <dimen name="select_feature_bag_view_width">70dp</dimen>
+    <dimen name="select_feature_bag_view_height">70dp</dimen>
+    <dimen name="select_feature_glasses_view_width">90dp</dimen>
+    <dimen name="select_feature_glasses_view_height">50dp</dimen>
+    <dimen name="select_feature_hat_view_width">100dp</dimen>
+    <dimen name="select_feature_hat_view_height">60dp</dimen>
+    <dimen name="select_feature_necklace_view_width">80dp</dimen>
+    <dimen name="select_feature_necklace_view_height">50dp</dimen>
+
+    <dimen name="handbag_">30dp</dimen>
+    <dimen name="select_feature_linear_layout_width">135dp</dimen>
+    <dimen name="select_feature_linear_layout_height">225dp</dimen>
+    <dimen name="final_avatar_text_view_text_size">18sp</dimen>
+    <dimen name="select_feature_image_height">120dp</dimen>
+    <dimen name="select_feature_tv_paid_top_margin_small">45dp</dimen>
+    <dimen name="select_feature_tv_paid_left_margin_small">15dp</dimen>
+    <dimen name="select_feature_tv_paid_size_small">32sp</dimen>
+    <dimen name="text_view_necklace">18sp</dimen>
+
+
+</resources>

--- a/PowerUp/app/src/main/res/values-large/dimens.xml
+++ b/PowerUp/app/src/main/res/values-large/dimens.xml
@@ -29,6 +29,7 @@
     <dimen name="select_feature_tv_paid_left_margin_small">15dp</dimen>
     <dimen name="select_feature_tv_paid_size_small">32sp</dimen>
     <dimen name="text_view_necklace">18sp</dimen>
+    <dimen name="final_avatar_text_size">25sp</dimen>
 
 
 </resources>

--- a/PowerUp/app/src/main/res/values-xlarge/dimens.xml
+++ b/PowerUp/app/src/main/res/values-xlarge/dimens.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="face_view_width">200dp</dimen>
+    <dimen name="face_view_height">240dp</dimen>
+    <dimen name="eye_view_width">100dp</dimen>
+    <dimen name="eye_view_height">100dp</dimen>
+    <dimen name="eye_view_margin_bottom">60dp</dimen>
+    <dimen name="hair_view_width">300dp</dimen>
+    <dimen name="hair_view_height">300dp</dimen>
+    <dimen name="cloth_view_width">150dp</dimen>
+    <dimen name="cloth_view_height">400dp</dimen>
+    <dimen name="select_feature_bag_view_width">140dp</dimen>
+    <dimen name="select_feature_bag_view_height">140dp</dimen>
+    <dimen name="select_feature_glasses_view_width">180dp</dimen>
+    <dimen name="select_feature_glasses_view_height">100dp</dimen>
+    <dimen name="select_feature_hat_view_width">200dp</dimen>
+    <dimen name="select_feature_hat_view_height">120dp</dimen>
+    <dimen name="select_feature_necklace_view_width">160dp</dimen>
+    <dimen name="select_feature_necklace_view_height">100dp</dimen>
+
+    <dimen name="handbag_">43dp</dimen>
+    <dimen name="select_feature_linear_layout_width">195dp</dimen>
+    <dimen name="select_feature_linear_layout_height">324dp</dimen>
+    <dimen name="final_avatar_text_view_text_size">26sp</dimen>
+    <dimen name="select_feature_image_height">173dp</dimen>
+    <dimen name="select_feature_tv_paid_top_margin_small">65dp</dimen>
+    <dimen name="select_feature_tv_paid_left_margin_small">22dp</dimen>
+    <dimen name="select_feature_tv_paid_size_small">46sp</dimen>
+    <dimen name="text_view_necklace">27sp</dimen>
+</resources>

--- a/PowerUp/app/src/main/res/values-xlarge/dimens.xml
+++ b/PowerUp/app/src/main/res/values-xlarge/dimens.xml
@@ -27,4 +27,5 @@
     <dimen name="select_feature_tv_paid_left_margin_small">22dp</dimen>
     <dimen name="select_feature_tv_paid_size_small">46sp</dimen>
     <dimen name="text_view_necklace">27sp</dimen>
+    <dimen name="final_avatar_text_size">34sp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -84,7 +84,7 @@
     <dimen name="avatar_room_continue_button">50dp</dimen>
     <dimen name="simple_row_text_view_padding">10dp</dimen>
     <dimen name="final_avatar_text_view_margin_top">70dp</dimen>
-    <dimen name="final_avatar_text_view_text_size">20sp</dimen>
+    <dimen name="final_avatar_text_view_text_size">12sp</dimen>
     <dimen name="avatar_margin">40dp</dimen>
     <dimen name="avatar_face_view_land_margin_top">72dp</dimen>
     <dimen name="avatar_hair_view_land_margin_top">70dp</dimen>
@@ -115,10 +115,10 @@
     <dimen name="select_feature_glasses_view_height_landscape">60dp</dimen>
     <dimen name="select_feature_linear_layout_width">90dp</dimen>
     <dimen name="select_feature_linear_layout_height">150dp</dimen>
-    <dimen name="select_feature_linear_layout_margin_top">30dp</dimen>
+    <dimen name="select_feature_linear_layout_margin_top">10dp</dimen>
     <dimen name="select_feature_linear_layout_margin_left">20dp</dimen>
     <dimen name="select_feature_image_height">80dp</dimen>
-    <dimen name="text_view_necklace">18sp</dimen>
+    <dimen name="text_view_necklace">12sp</dimen>
     <dimen name="select_feature_linear_layout_width_landscape">90dp</dimen>
     <dimen name="select_feature_linear_layout_height_landscape">150dp</dimen>
     <dimen name="select_feature_linear_layout_margin_top_landscape">10dp</dimen>
@@ -177,4 +177,8 @@
     <dimen name="karma_imageview_margin_top">5dp</dimen>
     <dimen name="health_power_bar_margin_right">20dp</dimen>
     <dimen name="scenarioNameEditText_margin_top">-4dp</dimen>
+    <dimen name="horizontal_holder_marginRight">20dp</dimen>
+    <dimen name="horizontal_holder_marginTop">20dp</dimen>
+    <dimen name="hat_marginRight">20dp</dimen>
+    <dimen name="relative2_marginLeft">10dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -181,4 +181,5 @@
     <dimen name="horizontal_holder_marginTop">20dp</dimen>
     <dimen name="hat_marginRight">20dp</dimen>
     <dimen name="relative2_marginLeft">10dp</dimen>
+    <dimen name="final_avatar_text_size">18sp</dimen>
 </resources>


### PR DESCRIPTION
Fix #326 
The Accessories Dressing room now supports all screen sizes. The tweaks made are -

Added some linear layouts around selection boxes with layout_weight property so they can adjust to any screen size. To scale them properly for big screen sizes, I have created 2 dimens.xml files - large and x-large. 

Nexus One 
<img src="https://cloud.githubusercontent.com/assets/13872065/25036617/6849cd32-2112-11e7-8947-150187476118.png" height="400" width="240">

I have tested it on Nexus One, Nexus S, Nexus 4, Nexus 4X, Nexus 5, Nexus 5X, Nexus 6, Nexus 6p, Nexus 9, Nexus 10 (tablet), MotoX Style, Galaxy Nexus, Pixel C, Pixel XL and many more devices. It working fine on all these devices.