### PR TITLE
Intial Possessions of Avatar reflected in Store now

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -245,6 +245,8 @@ public class AvatarRoomActivity extends Activity {
                 SessionHistory.currSessionID = 1;
                 SessionHistory.currScenePoints = 0;
                 getmDbHandler().resetPurchase();
+                getmDbHandler().setPurchasedHair(hair);
+                getmDbHandler().setPurchasedClothes(cloth);
                 Random random = new Random();
                 Integer healing = random.nextInt(101 - 1) + 1;
                 getmDbHandler().setHealing(healing);

--- a/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/SelectFeaturesActivity.java
@@ -166,6 +166,11 @@ public class SelectFeaturesActivity extends AppCompatActivity {
             linearLayoutHat.setVisibility(View.GONE);
             linearLayoutNecklace.setVisibility(View.GONE);
             imageViewSelectFeature.setImageDrawable(getResources().getDrawable(R.drawable.cloth1));
+            int isPurchased = getmDbHandler().getPurchasedClothes(1);
+            if (isPurchased == 1) {
+                imageViewSelectFeature.setAlpha((float) 0.5);
+                tvPaidSelectFeature.setText(getResources().getString(R.string.paid_feature));
+            }
             TextView tv = (TextView) findViewById(R.id.textViewSelectFeature);
             tvPoints = (TextView) findViewById(R.id.tvSelectFeaturePoints);
             tvPoints.setText(String.valueOf(getmDbHandler().getPointsClothes(cloth)));
@@ -202,6 +207,11 @@ public class SelectFeaturesActivity extends AppCompatActivity {
             linearLayoutHat.setVisibility(View.GONE);
             linearLayoutNecklace.setVisibility(View.GONE);
             imageViewSelectFeature.setImageDrawable(getResources().getDrawable(R.drawable.hair1));
+            int isPurchased = getmDbHandler().getPurchasedHair(1);
+            if (isPurchased == 1) {
+                imageViewSelectFeature.setAlpha((float) 0.5);
+                tvPaidSelectFeature.setText(getResources().getString(R.string.paid_feature));
+            }
             TextView tv = (TextView) findViewById(R.id.textViewSelectFeature);
             tvPoints = (TextView) findViewById(R.id.tvSelectFeaturePoints);
             tvPoints.setText(String.valueOf(getmDbHandler().getPointsHair(hair)));


### PR DESCRIPTION
Fix #371 , items chosen for new player are shown as "PAID" in store.