### PR TITLE
Converted library version in to variables in Gradle

### DIFF
--- a/PowerUp/app/build.gradle
+++ b/PowerUp/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    compileSdkVersion rootProject.appCompileSdkVersion
+    buildToolsVersion rootProject.appBuildToolsVersion
 
     defaultConfig {
         applicationId "powerup.systers.com.powerup"
-        minSdkVersion 15
-        targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion rootProject.appMinSdkVersion
+        targetSdkVersion rootProject.appTargetSdkVersion
+        versionCode rootProject.appVersionCode
+        versionName rootProject.appVersionName
     }
 
     testOptions {
@@ -27,11 +27,11 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.3.0'
-    testCompile "org.mockito:mockito-core:1.+"
+    compile "com.android.support:appcompat-v7: $rootProject.supportLibVersion"
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.10.0'
     testCompile "org.robolectric:robolectric:3.3.1"
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support:support-annotations:23.3.0'
+    androidTestCompile "com.android.support:support-annotations:$rootProject.supportLibVersion"
     compile 'com.akexorcist:RoundCornerProgressBar:2.0.3'
 }

--- a/PowerUp/build.gradle
+++ b/PowerUp/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,4 +16,18 @@ allprojects {
     repositories {
         jcenter()
     }
+
+
+    ext {
+        supportLibVersion = '25.3.1'
+        appBuildToolsVersion = '25.0.0'
+
+        appCompileSdkVersion = 23
+        appMinSdkVersion = 15
+        appTargetSdkVersion = 23
+
+        appVersionCode = 1
+        appVersionName = "1.0"
+    }
+
 }


### PR DESCRIPTION
1. Converted support library versions to variable so we need to update only variable when new version available
2. Changed mockito version 1.+ to specific version as we should define a specific version (Version like 1.+ will check every time in a 24 hour if new version is available, which increases Gradle build time )
3. Updated version to latest one