### PR TITLE
Added margins to scenario description

### DIFF
--- a/PowerUp/app/src/main/res/layout-land/game_activity.xml
+++ b/PowerUp/app/src/main/res/layout-land/game_activity.xml
@@ -14,6 +14,8 @@
         android:layout_width="wrap_content"
         android:layout_height="@dimen/karma_star_height"
         android:layout_alignParentTop="true"
+        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/scenario_description_marginTop"
         android:background="@android:color/transparent"
         android:backgroundTint="@color/abc_primary_text_disable_only_material_dark"
         android:ems="@integer/text_view_ems"

--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -238,4 +238,5 @@
     <dimen name="replay_marginTop">400dp</dimen>
     <dimen name="replay_marginLeft">180dp</dimen>
     <dimen name="hair_button_marginLeft">100dp</dimen>
+    <dimen name="scenario_description_marginTop">6dp</dimen>
 </resources>


### PR DESCRIPTION
I added margins to scenario descriptions. 

Screenshot (Before)
![screen shot 2017-12-14 at 8 51 04 pm](https://user-images.githubusercontent.com/30840527/34005857-4eae714a-e122-11e7-9604-84602469d679.png)

Screenshot (After)
![screen shot 2017-12-14 at 9 13 25 pm](https://user-images.githubusercontent.com/30840527/34005873-5bd74414-e122-11e7-8a0a-93716d656bc1.png)
