### PR TITLE
Add fade-in transition to all activities.

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -240,6 +240,7 @@ public class AvatarRoomActivity extends Activity {
                 }
                 finish();
                 startActivityForResult(new Intent(AvatarRoomActivity.this, MapActivity.class), 0);
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
 
             }
         });

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -58,6 +58,7 @@ public class GameActivity extends Activity {
 
         if (new MinesweeperSessionManager(this).isMinesweeperOpened()) {
             startActivity(new Intent(GameActivity.this, MinesweeperGameActivity.class));
+            overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
         }
         if (savedInstanceState != null) {
             isStateChanged = true;
@@ -218,6 +219,7 @@ public class GameActivity extends Activity {
                     Intent intent = new Intent(GameActivity.this, MapActivity.class);
                     intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     startActivityForResult(intent, 0);
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                     getmDbHandler()
                             .setReplayedScenario(scene.getScenarioName());
                     goToMap.setAlpha((float) 0.0);
@@ -234,13 +236,17 @@ public class GameActivity extends Activity {
                     Intent intent = new Intent(GameActivity.this, ScenarioOverActivity.class);
                     intent.putExtra(String.valueOf(R.string.scene), prevScene.getScenarioName());
                     startActivity(intent);
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 } else if (type == -1) {
                     new MinesweeperSessionManager(this).saveMinesweeperOpenedStatus(true); //marks minesweeper game as opened and incompleted
                     startActivity(new Intent(GameActivity.this, MinesweeperTutorials.class));
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 } else if (type == -2) {
                     startActivity(new Intent(GameActivity.this, SinkToSwimTutorials.class));
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 } else if (type == -3) {
                     startActivity(new Intent(GameActivity.this, VocabMatchTutorials.class));
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 }
 
         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
@@ -28,6 +28,7 @@ public class GameOverActivity extends Activity {
                         MapActivity.class);
                 finish();
                 startActivityForResult(intent, 0);
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -36,6 +36,7 @@ public class MapActivity extends Activity {
                 intent.putExtra(PowerUpUtils.SOURCE,PowerUpUtils.MAP);
                 startActivityForResult(intent, 0);
             }
+            overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             finish();
         }}
     };
@@ -91,6 +92,7 @@ public class MapActivity extends Activity {
             @Override
             public void onClick(View v) {
                 startActivity(new Intent(MapActivity.this, StoreActivity.class));
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
 
@@ -99,6 +101,7 @@ public class MapActivity extends Activity {
             public void onClick(View v) {
                 finish();
                 startActivity(new Intent(MapActivity.this,StartActivity.class));
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -53,6 +53,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
             public void onClick(View v) {
                 finish();
                 startActivity(new Intent(ScenarioOverActivity.this, MapActivity.class));
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
 
@@ -64,6 +65,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
             public void onClick(View v) {
                 new GameActivity().gameActivityInstance.finish();
                 startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
         if (getIntent().getExtras()!=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE))){
@@ -85,6 +87,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
                 new GameActivity().gameActivityInstance.finish();
                 scenarioOverActivityInstance.finish();
                 startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -49,6 +49,7 @@ public class StartActivity extends Activity {
                 builder.setPositiveButton(getString(R.string.start_confirm_message), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
+                        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                     }
                 });
                 builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
@@ -74,7 +75,7 @@ public class StartActivity extends Activity {
                 } else {
                     startActivity(new Intent(StartActivity.this, AvatarRoomActivity.class));
                 }
-
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
 
@@ -83,6 +84,7 @@ public class StartActivity extends Activity {
             @Override
             public void onClick(View view) {
                 startActivity(new Intent(StartActivity.this, AboutActivity.class));
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
@@ -61,6 +61,7 @@ public class StoreActivity extends AppCompatActivity {
             public void onClick(View v) {
                 finish();
                 startActivity(new Intent(StoreActivity.this,MapActivity.class));
+                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
             }
         });
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperTutorials.java
@@ -27,6 +27,7 @@ public class MinesweeperTutorials extends AppCompatActivity {
                     Intent intent = new Intent(MinesweeperTutorials.this,MinesweeperGameActivity.class).putExtra(PowerUpUtils.CALLED_BY, true);
                     finish();
                     startActivity(intent);
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 }else {
                     tutorialView.setImageDrawable(getResources().getDrawable(PowerUpUtils.MINES_TUTS[curTutorialImage]));
                     curTutorialImage++;

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
@@ -48,6 +48,7 @@ public class ProsAndConsActivity extends AppCompatActivity {
             intent.putExtra(String.valueOf(R.string.scene), PowerUpUtils.MINESWEEP_PREVIOUS_SCENARIO);
             startActivity(intent);
         }
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
     }
 
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
@@ -32,5 +32,6 @@ public class SinkToSwimEndActivity extends AppCompatActivity {
         Intent intent = new Intent(SinkToSwimEndActivity.this, GameOverActivity.class);
         finish();
         startActivityForResult(intent, 0);
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
@@ -123,6 +123,7 @@ public class SinkToSwimGame extends AppCompatActivity {
         intent.putExtra(PowerUpUtils.WRONG_ANSWER,wrongAnswers);
         finish();
         startActivity(intent);
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
     }
 
     /**

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimTutorials.java
@@ -46,6 +46,7 @@ public class SinkToSwimTutorials extends AppCompatActivity {
                     Intent intent = new Intent(SinkToSwimTutorials.this,SinkToSwimGame.class);
                     finish();
                     startActivity(intent);
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 }
             }
         });

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
@@ -35,5 +35,6 @@ public class VocabMatchEndActivity extends AppCompatActivity {
         Intent intent = new Intent(VocabMatchEndActivity.this, ScenarioOverActivity.class);
         finish();
         startActivity(intent);
+        overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -143,6 +143,7 @@ public class VocabMatchGameActivity extends AppCompatActivity {
                     intent.putExtra(PowerUpUtils.SCORE,score);
                     finish();
                     startActivity(intent);
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 }
 
             }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchTutorials.java
@@ -27,6 +27,7 @@ public class VocabMatchTutorials extends AppCompatActivity {
                     Intent intent = new Intent(VocabMatchTutorials.this,VocabMatchGameActivity.class);
                     finish();
                     startActivity(intent);
+                    overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
                 }else {
                     tutorialView.setImageDrawable(getResources().getDrawable(PowerUpUtils.VOCAB_MATCH_TUTS[curTutorialImage]));
                     curTutorialImage++;


### PR DESCRIPTION
### Description
Add fade-in transition to the start of the following activities:
- AvatarRoomActivity
- GameActivity
- GameOverActivity
- MapActivity
- ScenarioOverActivity
- StartActivity
- StoreActivity
- MinesweeperTutorials
- ProsAndConsActivity
- SinkToSwimGame
- SinkToSwimEndActivity
- SinkToSwimTutorials
- VocabMatchGameActivity
- VocabMatchTutorials
- VocabMatchEndActivity

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] New and existing unit tests pass locally with my changes
