### PR TITLE
Add animation to activity transition intents

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AboutActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AboutActivity.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
 
+import powerup.systers.com.powerup.PowerUpUtils;
+
 public class AboutActivity extends Activity {
 
     private boolean isAboutGameOpen = false;
@@ -68,7 +70,7 @@ public class AboutActivity extends Activity {
     }
 
     public void pressHomeButton(View view){
-        finish();
+        PowerUpUtils.animateActivity(this, true);
     }
 
     @Override

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -17,6 +17,7 @@ import java.util.Random;
 
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
+import powerup.systers.com.powerup.PowerUpUtils;
 
 public class AvatarRoomActivity extends Activity {
 
@@ -238,9 +239,8 @@ public class AvatarRoomActivity extends Activity {
                     edit.putBoolean(getString(R.string.preferences_has_previously_started), Boolean.TRUE);
                     edit.apply();
                 }
-                finish();
                 startActivityForResult(new Intent(AvatarRoomActivity.this, MapActivity.class), 0);
-
+                PowerUpUtils.animateActivity(AvatarRoomActivity.this, true);
             }
         });
         getmDbHandler().close();

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -58,6 +58,7 @@ public class GameActivity extends Activity {
 
         if (new MinesweeperSessionManager(this).isMinesweeperOpened()) {
             startActivity(new Intent(GameActivity.this, MinesweeperGameActivity.class));
+            PowerUpUtils.animateActivity(this, false);
         }
         if (savedInstanceState != null) {
             isStateChanged = true;
@@ -218,6 +219,7 @@ public class GameActivity extends Activity {
                     Intent intent = new Intent(GameActivity.this, MapActivity.class);
                     intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     startActivityForResult(intent, 0);
+                    PowerUpUtils.animateActivity(GameActivity.this, false);
                     getmDbHandler()
                             .setReplayedScenario(scene.getScenarioName());
                     goToMap.setAlpha((float) 0.0);
@@ -242,7 +244,7 @@ public class GameActivity extends Activity {
                 } else if (type == -3) {
                     startActivity(new Intent(GameActivity.this, VocabMatchTutorials.class));
                 }
-
+                PowerUpUtils.animateActivity(this, false);
         }
 
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
@@ -11,6 +11,8 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
+import powerup.systers.com.powerup.PowerUpUtils;
+
 public class GameOverActivity extends Activity {
 
     /**
@@ -26,8 +28,8 @@ public class GameOverActivity extends Activity {
             public void onClick(View v) {
                 Intent intent = new Intent(GameOverActivity.this,
                         MapActivity.class);
-                finish();
                 startActivityForResult(intent, 0);
+                PowerUpUtils.animateActivity(GameOverActivity.this, true);
             }
         });
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -36,7 +36,7 @@ public class MapActivity extends Activity {
                 intent.putExtra(PowerUpUtils.SOURCE,PowerUpUtils.MAP);
                 startActivityForResult(intent, 0);
             }
-            finish();
+            PowerUpUtils.animateActivity(MapActivity.this, true);
         }}
     };
 
@@ -91,14 +91,15 @@ public class MapActivity extends Activity {
             @Override
             public void onClick(View v) {
                 startActivity(new Intent(MapActivity.this, StoreActivity.class));
+                PowerUpUtils.animateActivity(MapActivity.this, false);
             }
         });
 
         homeButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                finish();
                 startActivity(new Intent(MapActivity.this,StartActivity.class));
+                PowerUpUtils.animateActivity(MapActivity.this, true);
             }
         });
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -51,8 +51,8 @@ public class ScenarioOverActivity extends AppCompatActivity {
         mapButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                finish();
                 startActivity(new Intent(ScenarioOverActivity.this, MapActivity.class));
+                PowerUpUtils.animateActivity(ScenarioOverActivity.this, true);
             }
         });
 
@@ -64,6 +64,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
             public void onClick(View v) {
                 new GameActivity().gameActivityInstance.finish();
                 startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+                PowerUpUtils.animateActivity(ScenarioOverActivity.this, false);
             }
         });
         if (getIntent().getExtras()!=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE))){
@@ -85,6 +86,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
                 new GameActivity().gameActivityInstance.finish();
                 scenarioOverActivityInstance.finish();
                 startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+                PowerUpUtils.animateActivity(ScenarioOverActivity.this, false);
             }
         });
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/SplashActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/SplashActivity.java
@@ -5,6 +5,8 @@ import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 
+import powerup.systers.com.powerup.PowerUpUtils;
+
 public class SplashActivity extends AppCompatActivity {
 
     @Override
@@ -15,8 +17,7 @@ public class SplashActivity extends AppCompatActivity {
             public void run() {
                 Intent intent = new Intent(SplashActivity.this, StartActivity.class);
                 startActivity(intent);
-                overridePendingTransition(R.animator.fade_in, R.animator.fade_out);
-                finish();
+                PowerUpUtils.animateActivity(SplashActivity.this, true);
             }
         },1000);
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -23,6 +23,8 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.Toast;
 
+import powerup.systers.com.powerup.PowerUpUtils;
+
 public class StartActivity extends Activity {
 
     private SharedPreferences preferences;
@@ -49,6 +51,7 @@ public class StartActivity extends Activity {
                 builder.setPositiveButton(getString(R.string.start_confirm_message), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
+                        PowerUpUtils.animateActivity(StartActivity.this, false);
                     }
                 });
                 builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
@@ -74,7 +77,7 @@ public class StartActivity extends Activity {
                 } else {
                     startActivity(new Intent(StartActivity.this, AvatarRoomActivity.class));
                 }
-
+                PowerUpUtils.animateActivity(StartActivity.this, false);
             }
         });
 
@@ -83,6 +86,7 @@ public class StartActivity extends Activity {
             @Override
             public void onClick(View view) {
                 startActivity(new Intent(StartActivity.this, AboutActivity.class));
+                PowerUpUtils.animateActivity(StartActivity.this, false);
             }
         });
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
@@ -59,8 +59,8 @@ public class StoreActivity extends AppCompatActivity {
         mapButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                finish();
                 startActivity(new Intent(StoreActivity.this,MapActivity.class));
+                PowerUpUtils.animateActivity(StoreActivity.this, true);
             }
         });
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperGameActivity.java
@@ -231,9 +231,8 @@ public class MinesweeperGameActivity extends AppCompatActivity {
     public void continuePressed(View view) {
         MinesweeperSessionManager session = new MinesweeperSessionManager(this);
         session.saveData(score, gameRound);
-        finish();
         startActivity(new Intent(MinesweeperGameActivity.this, ProsAndConsActivity.class));
-        overridePendingTransition(R.animator.fade_in, R.animator.fade_out);
+        PowerUpUtils.animateActivity(MinesweeperGameActivity.this, true);
     }
 
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperTutorials.java
@@ -25,8 +25,8 @@ public class MinesweeperTutorials extends AppCompatActivity {
             public void onClick(View v) {
                 if(curTutorialImage == PowerUpUtils.MINES_TUTS.length){
                     Intent intent = new Intent(MinesweeperTutorials.this,MinesweeperGameActivity.class).putExtra(PowerUpUtils.CALLED_BY, true);
-                    finish();
                     startActivity(intent);
+                    PowerUpUtils.animateActivity(MinesweeperTutorials.this, true);
                 }else {
                     tutorialView.setImageDrawable(getResources().getDrawable(PowerUpUtils.MINES_TUTS[curTutorialImage]));
                     curTutorialImage++;

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
@@ -48,6 +48,7 @@ public class ProsAndConsActivity extends AppCompatActivity {
             intent.putExtra(String.valueOf(R.string.scene), PowerUpUtils.MINESWEEP_PREVIOUS_SCENARIO);
             startActivity(intent);
         }
+        PowerUpUtils.animateActivity(this, false);
     }
 
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -1,5 +1,7 @@
 package powerup.systers.com.powerup;
 
+import android.app.Activity;
+
 import powerup.systers.com.R;
 
 /**
@@ -55,5 +57,17 @@ public class PowerUpUtils {
 
     public static final int[] ACCESSORIES_IMAGES = {R.drawable.acc1,R.drawable.acc2,R.drawable.acc3,R.drawable.acc4};
     public static final String[] ACCESSORIES_POINTS_TEXTS = {"10","5","5","10"};
+
+    /**
+     * This method helps reduce redundancy by packaging the animations of transitions between activities and the
+     * finish() method. It also saves debug time since one has to update the animations at a single location.
+     * @param activity Activity transition to be animated
+     * @param close Should we close the activity or not
+     */
+    public static void animateActivity(Activity activity, boolean close){
+        if(close)
+            activity.finish();
+        activity.overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
+    }
 }
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
@@ -30,7 +30,7 @@ public class SinkToSwimEndActivity extends AppCompatActivity {
 
     public void continuePressed(View view){
         Intent intent = new Intent(SinkToSwimEndActivity.this, GameOverActivity.class);
-        finish();
         startActivityForResult(intent, 0);
+        PowerUpUtils.animateActivity(this, true);
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
@@ -121,8 +121,8 @@ public class SinkToSwimGame extends AppCompatActivity {
         intent.putExtra(PowerUpUtils.SCORE,score);
         intent.putExtra(PowerUpUtils.CORRECT_ANSWERS,correctAnswers);
         intent.putExtra(PowerUpUtils.WRONG_ANSWER,wrongAnswers);
-        finish();
         startActivity(intent);
+        PowerUpUtils.animateActivity(this, true);
     }
 
     /**

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimTutorials.java
@@ -44,8 +44,8 @@ public class SinkToSwimTutorials extends AppCompatActivity {
             public void onClick(View v) {
                 if (startButton.isEnabled()){
                     Intent intent = new Intent(SinkToSwimTutorials.this,SinkToSwimGame.class);
-                    finish();
                     startActivity(intent);
+                    PowerUpUtils.animateActivity(SinkToSwimTutorials.this, true);
                 }
             }
         });

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
@@ -33,7 +33,7 @@ public class VocabMatchEndActivity extends AppCompatActivity {
 
     public void continuePressed(View view){
         Intent intent = new Intent(VocabMatchEndActivity.this, ScenarioOverActivity.class);
-        finish();
         startActivity(intent);
+        PowerUpUtils.animateActivity(this, true);
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -141,8 +141,8 @@ public class VocabMatchGameActivity extends AppCompatActivity {
                 } else if (latestTile == PowerUpUtils.VOCAB_TILES_IMAGES.length + 2){
                     Intent intent = new Intent(VocabMatchGameActivity.this,VocabMatchEndActivity.class);
                     intent.putExtra(PowerUpUtils.SCORE,score);
-                    finish();
                     startActivity(intent);
+                    PowerUpUtils.animateActivity(VocabMatchGameActivity.this, true);
                 }
 
             }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchTutorials.java
@@ -25,8 +25,8 @@ public class VocabMatchTutorials extends AppCompatActivity {
             public void onClick(View v) {
                 if(curTutorialImage == PowerUpUtils.VOCAB_MATCH_TUTS.length){
                     Intent intent = new Intent(VocabMatchTutorials.this,VocabMatchGameActivity.class);
-                    finish();
                     startActivity(intent);
+                    PowerUpUtils.animateActivity(VocabMatchTutorials.this, true);
                 }else {
                     tutorialView.setImageDrawable(getResources().getDrawable(PowerUpUtils.VOCAB_MATCH_TUTS[curTutorialImage]));
                     curTutorialImage++;


### PR DESCRIPTION
### Description
Fade in and fade out animations are added to intents transitioning between activities. I have made a centralized method in PowerUpUtils class that is called by each of the 18 activities, to ensure least redundancy and ability to change the animation between activities with a minimal amount of work.

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Tested it on various devices including Intex and Redmi


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
