### PR TITLE
Reduced transition timings of questions in SinkToSwim minigame

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
@@ -138,10 +138,10 @@ public class SinkToSwimGame extends AppCompatActivity {
         final AlphaAnimation fadeIn = new AlphaAnimation(0.0f, 1.0f);
         final AlphaAnimation fadeOut = new AlphaAnimation(1f, 0f);
         fadeOut.setFillAfter(true);
-        fadeIn.setDuration(800);
-        fadeOut.setDuration(800);
+        fadeIn.setDuration(600);
+        fadeOut.setDuration(600);
         fadeIn.setFillAfter(true);
-        fadeIn.setStartOffset(500);
+        fadeIn.setStartOffset(300);
         fadeOut.setAnimationListener(new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {
@@ -198,6 +198,7 @@ public class SinkToSwimGame extends AppCompatActivity {
                 questionView.setBackground(getResources().getDrawable(R.drawable.swim_cross));
                 wrongAnswers++;
             }
+            questionView.setText("");
         } else if (view == findViewById(R.id.false_option)) {
             if (PowerUpUtils.SWIM_SINK_QUESTION_ANSWERS[curQuestion][1] == "F") {
                 score += 1;
@@ -208,9 +209,9 @@ public class SinkToSwimGame extends AppCompatActivity {
                 questionView.setBackground(getResources().getDrawable(R.drawable.swim_cross));
                 wrongAnswers++;
             }
+            questionView.setText("");
         }
 
-        questionView.setText("");
         showNextQuestion();
         scoreView.setText("Score: " + score);
     }


### PR DESCRIPTION
### Description

Initially, the transition timings of questions in minigame SinkToSwim were quite slow. Through this PR, I have tries to reduce the animation transition timings to enhance the UX.

Fixes #523 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Refer to GIF here (Though it might appear a bit slow): 
https://user-images.githubusercontent.com/26908195/31807843-006472d8-b58e-11e7-994b-9d497b8eb98f.gif
Steps to Reproduce:
1. Press True button in SinkToSwim game
2. Press False button in SinkToSwim game
3. Press Skip button in SinkToSwim game

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
