### PR TITLE
Program: GCI Improve Code Coverage

### DIFF
--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/GameOverActivityTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/GameOverActivityTests.java
@@ -1,0 +1,59 @@
+package powerup.systers.com.powerup.test;
+
+import android.os.Build;
+import android.widget.Button;
+import android.content.Intent;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+
+import powerup.systers.com.BuildConfig;
+import powerup.systers.com.GameOverActivity;
+import powerup.systers.com.MapActivity;
+import powerup.systers.com.R;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by yuyuanluo on 12/27/17.
+ */
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
+
+public class GameOverActivityTests {
+    GameOverActivity activity;
+    Button backToMap;
+
+    @Before
+    public void setUp() throws Exception {
+        activity = Robolectric.buildActivity(GameOverActivity.class)
+                .create()
+                .resume()
+                .get();
+        backToMap = (Button) activity.findViewById(R.id.ContinueButtonMap);
+    }
+
+    @Test
+    public void shouldNotBeNull() throws Exception {
+        assertNotNull(activity);
+    }
+
+    @Test
+    public void backToMap() throws Exception{
+        Intent expectedIntent = new Intent(activity, MapActivity.class);
+
+        backToMap.callOnClick();
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        Intent actualIntent = shadowActivity.getNextStartedActivity();
+
+        assertTrue(expectedIntent.filterEquals(actualIntent));
+    }
+}

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/ScenarioOverActivityTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/ScenarioOverActivityTests.java
@@ -1,0 +1,114 @@
+package powerup.systers.com.powerup.test;
+
+import android.content.Intent;
+import android.os.Build;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.annotation.Config;
+
+import powerup.systers.com.BuildConfig;
+import powerup.systers.com.GameActivity;
+import powerup.systers.com.MapActivity;
+import powerup.systers.com.R;
+import powerup.systers.com.ScenarioOverActivity;
+import powerup.systers.com.datamodel.SessionHistory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by yuyuanluo on 12/27/17.
+ */
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
+
+public class ScenarioOverActivityTests {
+    ScenarioOverActivity activity;
+
+    @Before
+    public void setUp() throws Exception {
+        activity = Robolectric.buildActivity(ScenarioOverActivity.class)
+                .create()
+                .resume()
+                .get();
+    }
+
+    @Test
+    public void shouldNotBeNull() throws Exception {
+        assertNotNull(activity);
+    }
+
+    @Test
+    public void mapButtonShouldLaunchMap() throws Exception {
+        Intent expectedIntent = new Intent(activity, MapActivity.class);
+
+        Button mapButton = (Button) activity.findViewById(R.id.mapButton);
+        mapButton.callOnClick();
+
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        Intent actualIntent = shadowActivity.getNextStartedActivity();
+
+        assertTrue(expectedIntent.filterEquals(actualIntent));
+    }
+
+    @Test
+    public void karmaPointsUpdated(){
+        SessionHistory.totalPoints += 50;
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        TextView karmaPoints = (TextView) shadowActivity.findViewById(R.id.karmaPoints);
+        karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+
+        assertEquals(karmaPoints.getText().toString(),String.valueOf(SessionHistory.totalPoints));
+
+        SessionHistory.totalPoints -= 50;
+    }
+
+    @Test
+    public void continueButtonWorks(){
+        Intent expectedIntent = new Intent(activity, GameActivity.class);
+
+        ImageView continueButton = (ImageView) activity.findViewById(R.id.continueButton);
+        continueButton.callOnClick();
+
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        Intent actualIntent = shadowActivity.getNextStartedActivity();
+
+        assertTrue(expectedIntent.filterEquals(actualIntent));
+    }
+
+    @Test
+    public void replayButtonWorks(){
+        ImageView replayButton = (ImageView) activity.findViewById(R.id.replayButton);
+        replayButton.callOnClick();
+        assertEquals(SessionHistory.currSessionID, SessionHistory.prevSessionID);
+        assertEquals(SessionHistory.totalPoints, SessionHistory.totalPoints - SessionHistory.currScenePoints);
+        assertEquals(SessionHistory.currScenePoints, 0);
+        assertEquals(activity.scenarioActivityDone, 0);
+        new GameActivity().gameActivityInstance.isFinishing();
+        activity.scenarioOverActivityInstance.isFinishing();
+
+        Intent expectedIntent = new Intent(activity, GameActivity.class);
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        Intent actualIntent = shadowActivity.getNextStartedActivity();
+
+        assertTrue(expectedIntent.filterEquals(actualIntent));
+    }
+
+    @Test
+    public void shouldCloseActivity() throws Exception{
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        activity.onBackPressed();
+        assertTrue(shadowActivity.isFinishing());
+    }
+}


### PR DESCRIPTION
There are originally no tests for the GameOverActivity and the ScenarioOverActivity, so their original coverage would be 0%. I added the tests, and their coverage increased to:
![screen shot 2017-12-27 at 1 54 44 pm](https://user-images.githubusercontent.com/34554308/34390553-79dcf210-eb0e-11e7-8ca4-eb93466dd3c2.png)

Here are some screenshots of more detailed reports:
![screen shot 2017-12-27 at 1 54 59 pm](https://user-images.githubusercontent.com/34554308/34390565-9176bfd2-eb0e-11e7-955f-ccfc55d4564d.png)
![screen shot 2017-12-27 at 1 55 44 pm](https://user-images.githubusercontent.com/34554308/34390573-a0bc34ae-eb0e-11e7-8083-7339a6e58810.png)

Here is a screenshot of the code I was not able to test:
![screen shot 2017-12-27 at 2 03 15 pm](https://user-images.githubusercontent.com/34554308/34390590-c475371a-eb0e-11e7-856c-e68d1853a4e3.png)


I used the IntelliJ method to test the code coverage, which came with the Android Studio.