### PR TITLE
Program: GCI - Fixes StartActivity buttons at first launch

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -43,24 +43,28 @@ public class StartActivity extends Activity {
         newUserButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(StartActivity.this);
-                builder.setTitle(context.getResources().getString(R.string.start_title_message))
-                        .setMessage(getResources().getString(R.string.start_dialog_message));
-                builder.setPositiveButton(getString(R.string.start_confirm_message), new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
-                    }
-                });
-                builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        dialog.dismiss();
-                    }
-                });
-                AlertDialog dialog = builder.create();
-                ColorDrawable drawable = new ColorDrawable(Color.WHITE);
-                drawable.setAlpha(200);
-                dialog.getWindow().setBackgroundDrawable(drawable);
-                dialog.show();
+                if (hasPreviouslyStarted){
+                    AlertDialog.Builder builder = new AlertDialog.Builder(StartActivity.this);
+                    builder.setTitle(context.getResources().getString(R.string.start_title_message))
+                            .setMessage(getResources().getString(R.string.start_dialog_message));
+                    builder.setPositiveButton(getString(R.string.start_confirm_message), new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
+                        }
+                    });
+                    builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            dialog.dismiss();
+                        }
+                    });
+                    AlertDialog dialog = builder.create();
+                    ColorDrawable drawable = new ColorDrawable(Color.WHITE);
+                    drawable.setAlpha(200);
+                    dialog.getWindow().setBackgroundDrawable(drawable);
+                    dialog.show();
+                } else {
+                    startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
+                }
             }
         });
 
@@ -72,7 +76,19 @@ public class StartActivity extends Activity {
                 if (hasPreviouslyStarted) {
                     startActivity(new Intent(StartActivity.this, MapActivity.class));
                 } else {
-                    startActivity(new Intent(StartActivity.this, AvatarRoomActivity.class));
+                    AlertDialog.Builder builder = new AlertDialog.Builder(StartActivity.this);
+                    builder.setTitle(context.getResources().getString(R.string.load_title_message))
+                            .setMessage(getResources().getString(R.string.load_dialog_message));
+                    builder.setPositiveButton(getResources().getString(R.string.load_dismiss_message), new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            dialog.dismiss();
+                        }
+                    });
+                    AlertDialog dialog = builder.create();
+                    ColorDrawable drawable = new ColorDrawable(Color.WHITE);
+                    drawable.setAlpha(200);
+                    dialog.getWindow().setBackgroundDrawable(drawable);
+                    dialog.show();
                 }
 
             }

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,7 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="load_dialog_message">You have no previous karma points. Click on NEW GAME to begin.</string>
+    <string name="load_title_message">No karma points !</string>
+    <string name="load_dismiss_message">Dismiss</string>
 </resources>


### PR DESCRIPTION
### Description
Fixes StartActivity.java and strings.xml so that on the first launch of the app on a device, when the user clicks "NEW GAME", the user goes directly to Avatar Room instead of a warning dialog. Additionally, on the first launch, if the user clicks "LOAD GAME" a dialog message "You have no previous karma points. Click on NEW GAME to begin." shows instead of going to Avatar Activity.
Screenshot of change:
![screenshot_20171229-144254](https://user-images.githubusercontent.com/23027638/34430356-7a64a9f4-eca7-11e7-9ad5-4a670a3770b6.png)
![screenshot_20171229-143901](https://user-images.githubusercontent.com/23027638/34430358-7beb8658-eca7-11e7-857c-d55636e024f5.png)

### Type of Change:

- Code

### How Has This Been Tested?
I ran this on my phone(see screenshots above).

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings 