### PR TITLE
Program:GCI Create a final avatar screen

### DIFF
--- a/PowerUp/app/src/main/AndroidManifest.xml
+++ b/PowerUp/app/src/main/AndroidManifest.xml
@@ -114,13 +114,18 @@
             android:configChanges="orientation|keyboardHidden"
             android:label="@string/app_name"
             android:screenOrientation="landscape"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar"></activity>
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
         <activity android:name=".minesweeper.MinesweeperTutorials"
             android:configChanges="orientation|keyboardHidden"
             android:label="@string/app_name"
             android:screenOrientation="landscape"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-        </activity>
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+        <activity
+            android:name=".FinalAvatarActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:label="@string/app_name"
+            android:screenOrientation="landscape"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
     </application>
 
 </manifest>

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -21,6 +21,7 @@ import powerup.systers.com.db.DatabaseHandler;
 public class AvatarRoomActivity extends Activity {
 
     public Activity avatarRoomInstance;
+    public static boolean newAvatar = true;
     private DatabaseHandler mDbHandler;
     private ImageView eyeAvatar;
     private ImageView skinAvatar;
@@ -54,6 +55,54 @@ public class AvatarRoomActivity extends Activity {
         ImageView hairRight = (ImageView) findViewById(R.id.hair_right);
         ImageView continueButton = (ImageView) findViewById(R.id.continueButtonAvatar);
 
+        if (!newAvatar) {
+            eye = getmDbHandler().getAvatarEye();
+            String eyeImageName = getResources().getString(R.string.eye);
+            eyeImageName = eyeImageName + getmDbHandler().getAvatarEye();
+            R.drawable ourRID = new R.drawable();
+            java.lang.reflect.Field photoNameField;
+            try {
+                photoNameField = ourRID.getClass().getField(eyeImageName);
+                eyeAvatar.setImageResource(photoNameField.getInt(ourRID));
+            } catch (NoSuchFieldException | IllegalAccessException
+                    | IllegalArgumentException error) {
+                error.printStackTrace();
+            }
+
+            skin = getmDbHandler().getAvatarSkin();
+            String skinImageName = getResources().getString(R.string.skin);
+            skinImageName = skinImageName + getmDbHandler().getAvatarSkin();
+            try {
+                photoNameField = ourRID.getClass().getField(skinImageName);
+                skinAvatar.setImageResource(photoNameField.getInt(ourRID));
+            } catch (NoSuchFieldException | IllegalAccessException
+                    | IllegalArgumentException error) {
+                error.printStackTrace();
+            }
+
+            cloth = getmDbHandler().getAvatarCloth();
+            String clothImageName = getResources().getString(R.string.cloth);
+            clothImageName = clothImageName + getmDbHandler().getAvatarCloth();
+            try {
+                photoNameField = ourRID.getClass().getField(clothImageName);
+                clothAvatar.setImageResource(photoNameField.getInt(ourRID));
+            } catch (NoSuchFieldException | IllegalAccessException
+                    | IllegalArgumentException error) {
+                error.printStackTrace();
+            }
+
+            hair = getmDbHandler().getAvatarHair();
+            String hairImageName = getResources().getString(R.string.hair);
+            hairImageName = hairImageName + getmDbHandler().getAvatarHair();
+            try {
+                photoNameField = ourRID.getClass().getField(hairImageName);
+                hairAvatar.setImageResource(photoNameField.getInt(ourRID));
+            } catch (NoSuchFieldException | IllegalAccessException
+                    | IllegalArgumentException error) {
+                error.printStackTrace();
+            }
+        }
+        
         eyeLeft.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -225,21 +274,10 @@ public class AvatarRoomActivity extends Activity {
                 getmDbHandler().setAvatarCloth(cloth);
                 getmDbHandler().setPurchasedHair(hair);
                 getmDbHandler().setPurchasedClothes(cloth);
-                getmDbHandler().updateComplete();//set all the complete fields back to 0
-                getmDbHandler().updateReplayed();//set all the replayed fields back to 0
-                SessionHistory.totalPoints = 0;    //reset the points stored
-                SessionHistory.currSessionID = 1;
-                SessionHistory.currScenePoints = 0;
+                newAvatar = false;
 
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(AvatarRoomActivity.this);
-                boolean hasPreviouslyStarted = prefs.getBoolean(getString(R.string.preferences_has_previously_started), false);
-                if (!hasPreviouslyStarted) {
-                    SharedPreferences.Editor edit = prefs.edit();
-                    edit.putBoolean(getString(R.string.preferences_has_previously_started), Boolean.TRUE);
-                    edit.apply();
-                }
                 finish();
-                startActivityForResult(new Intent(AvatarRoomActivity.this, MapActivity.class), 0);
+                startActivity(new Intent(AvatarRoomActivity.this, FinalAvatarActivity.class));
 
             }
         });

--- a/PowerUp/app/src/main/java/powerup/systers/com/FinalAvatarActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/FinalAvatarActivity.java
@@ -1,0 +1,124 @@
+package powerup.systers.com;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import powerup.systers.com.R;
+import powerup.systers.com.datamodel.SessionHistory;
+import powerup.systers.com.db.DatabaseHandler;
+
+public class FinalAvatarActivity extends Activity {
+
+    public Activity finalAvatarInstance;
+    private DatabaseHandler mDbHandler;
+
+    public FinalAvatarActivity() {
+        finalAvatarInstance = this;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_final_avatar);
+
+        setmDbHandler(new DatabaseHandler(this));
+        getmDbHandler().open();
+
+        ImageView eyeImageView = (ImageView) findViewById(R.id.eye_view);
+        ImageView skinImageView = (ImageView) findViewById(R.id.skin_view);
+        ImageView hairImageView = (ImageView) findViewById(R.id.hair_view);
+        ImageView clothImageView = (ImageView) findViewById(R.id.dress_view);
+        ImageView continueButton = (ImageView) findViewById(R.id.continueButton);
+        ImageView backButton = (ImageView) findViewById(R.id.backButton);
+
+        String eyeImageName = getResources().getString(R.string.eye);
+        eyeImageName = eyeImageName + getmDbHandler().getAvatarEye();
+        R.drawable ourRID = new R.drawable();
+        java.lang.reflect.Field photoNameField;
+        try {
+            photoNameField = ourRID.getClass().getField(eyeImageName);
+            eyeImageView.setImageResource(photoNameField.getInt(ourRID));
+        } catch (NoSuchFieldException | IllegalAccessException
+                | IllegalArgumentException error) {
+            error.printStackTrace();
+        }
+
+        String skinImageName = getResources().getString(R.string.skin);
+        skinImageName = skinImageName + getmDbHandler().getAvatarSkin();
+        try {
+            photoNameField = ourRID.getClass().getField(skinImageName);
+            skinImageView.setImageResource(photoNameField.getInt(ourRID));
+        } catch (NoSuchFieldException | IllegalAccessException
+                | IllegalArgumentException error) {
+            error.printStackTrace();
+        }
+
+        String clothImageName = getResources().getString(R.string.cloth);
+        clothImageName = clothImageName + getmDbHandler().getAvatarCloth();
+        try {
+            photoNameField = ourRID.getClass().getField(clothImageName);
+            clothImageView.setImageResource(photoNameField.getInt(ourRID));
+        } catch (NoSuchFieldException | IllegalAccessException
+                | IllegalArgumentException error) {
+            error.printStackTrace();
+        }
+
+        String hairImageName = getResources().getString(R.string.hair);
+        hairImageName = hairImageName + getmDbHandler().getAvatarHair();
+        try {
+            photoNameField = ourRID.getClass().getField(hairImageName);
+            hairImageView.setImageResource(photoNameField.getInt(ourRID));
+        } catch (NoSuchFieldException | IllegalAccessException
+                | IllegalArgumentException error) {
+            error.printStackTrace();
+        }
+
+        continueButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                getmDbHandler().open();
+                getmDbHandler().updateComplete();//set all the complete fields back to 0
+                getmDbHandler().updateReplayed();//set all the replayed fields back to 0
+                SessionHistory.totalPoints = 0;    //reset the points stored
+                SessionHistory.currSessionID = 1;
+                SessionHistory.currScenePoints = 0;
+
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(FinalAvatarActivity.this);
+                boolean hasPreviouslyStarted = prefs.getBoolean(getString(R.string.preferences_has_previously_started), false);
+                if (!hasPreviouslyStarted) {
+                    SharedPreferences.Editor edit = prefs.edit();
+                    edit.putBoolean(getString(R.string.preferences_has_previously_started), Boolean.TRUE);
+                    edit.apply();
+                }
+                finish();
+                startActivity(new Intent(FinalAvatarActivity.this, MapActivity.class));
+            }
+        });
+
+        backButton.setOnClickListener((new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onBackPressed();
+            }
+        }));
+    }
+
+    public DatabaseHandler getmDbHandler() {
+        return mDbHandler;
+    }
+
+    public void setmDbHandler(DatabaseHandler mDbHandler) {
+        this.mDbHandler = mDbHandler;
+    }
+
+    @Override
+    public void onBackPressed() {
+        startActivity(new Intent(FinalAvatarActivity.this, AvatarRoomActivity.class));
+    }
+}

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -48,6 +48,7 @@ public class StartActivity extends Activity {
                         .setMessage(getResources().getString(R.string.start_dialog_message));
                 builder.setPositiveButton(getString(R.string.start_confirm_message), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
+                        AvatarRoomActivity.newAvatar = true;
                         startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
                     }
                 });

--- a/PowerUp/app/src/main/res/layout-land/avatar_room.xml
+++ b/PowerUp/app/src/main/res/layout-land/avatar_room.xml
@@ -13,20 +13,18 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"></LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
             android:layout_weight="10"
             android:orientation="horizontal">
 
             <ImageView
                 android:id="@+id/skin_left"
+                android:contentDescription="@string/skin_left_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/selection_margin_wide"
+                android:layout_marginStart="@dimen/selection_margin_wide"
                 android:layout_marginRight="@dimen/selection_margin_small"
+                android:layout_marginEnd="@dimen/selection_margin_small"
                 android:layout_weight="1"
                 android:src="@drawable/arrow_left" />
 
@@ -34,24 +32,30 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:gravity="center_vertical"
-                android:text="Skin"
+                android:text="@string/skin_text"
                 android:textSize="@dimen/selection_text_size" />
 
             <ImageView
                 android:id="@+id/skin_right"
+                android:contentDescription="@string/skin_right_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/selection_margin_small"
+                android:layout_marginStart="@dimen/selection_margin_small"
                 android:layout_marginRight="@dimen/selection_margin_wide"
+                android:layout_marginEnd="@dimen/selection_margin_wide"
                 android:layout_weight="1"
                 android:src="@drawable/arrow_right" />
 
             <ImageView
                 android:id="@+id/eyes_left"
+                android:contentDescription="@string/eye_left_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/selection_margin_wide"
+                android:layout_marginStart="@dimen/selection_margin_wide"
                 android:layout_marginRight="@dimen/selection_margin_small"
+                android:layout_marginEnd="@dimen/selection_margin_small"
                 android:layout_weight="1"
                 android:src="@drawable/arrow_left" />
 
@@ -59,24 +63,30 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:gravity="center_vertical"
-                android:text="Eyes"
+                android:text="@string/eye_text"
                 android:textSize="@dimen/selection_text_size" />
 
             <ImageView
                 android:id="@+id/eyes_right"
+                android:contentDescription="@string/eye_right_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/selection_margin_small"
+                android:layout_marginStart="@dimen/selection_margin_small"
                 android:layout_marginRight="@dimen/selection_margin_wide"
+                android:layout_marginEnd="@dimen/selection_margin_wide"
                 android:layout_weight="1"
                 android:src="@drawable/arrow_right" />
 
             <ImageView
                 android:id="@+id/clothes_left"
+                android:contentDescription="@string/cloth_left_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/selection_margin_wide"
+                android:layout_marginStart="@dimen/selection_margin_wide"
                 android:layout_marginRight="@dimen/selection_margin_small"
+                android:layout_marginEnd="@dimen/selection_margin_small"
                 android:layout_weight="1"
                 android:src="@drawable/arrow_left" />
 
@@ -84,24 +94,30 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:gravity="center_vertical"
-                android:text="Clothes"
+                android:text="@string/cloth_text"
                 android:textSize="@dimen/selection_text_size" />
 
             <ImageView
                 android:id="@+id/clothes_right"
+                android:contentDescription="@string/cloth_right_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/selection_margin_small"
+                android:layout_marginStart="@dimen/selection_margin_small"
                 android:layout_marginRight="@dimen/selection_margin_wide"
+                android:layout_marginEnd="@dimen/selection_margin_wide"
                 android:layout_weight="1"
                 android:src="@drawable/arrow_right" />
 
             <ImageView
                 android:id="@+id/hair_left"
+                android:contentDescription="@string/hair_left_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/selection_margin_wide"
+                android:layout_marginStart="@dimen/selection_margin_wide"
                 android:layout_marginRight="@dimen/selection_margin_small"
+                android:layout_marginEnd="@dimen/selection_margin_small"
                 android:layout_weight="1"
                 android:src="@drawable/arrow_left" />
 
@@ -109,15 +125,18 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:gravity="center_vertical"
-                android:text="Hair"
+                android:text="@string/hair_text"
                 android:textSize="@dimen/selection_text_size" />
 
             <ImageView
                 android:id="@+id/hair_right"
+                android:contentDescription="@string/hair_right_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/selection_margin_small"
+                android:layout_marginStart="@dimen/selection_margin_small"
                 android:layout_marginRight="@dimen/selection_margin_wide"
+                android:layout_marginEnd="@dimen/selection_margin_wide"
                 android:layout_weight="1"
                 android:src="@drawable/arrow_right" />
         </LinearLayout>
@@ -126,7 +145,8 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="20"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:baselineAligned="false">
 
             <LinearLayout
                 android:layout_width="0dp"
@@ -140,6 +160,7 @@
 
                 <ImageView
                     android:id="@+id/skin_view"
+                    android:contentDescription="@string/skin"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/skin1"
@@ -147,12 +168,14 @@
 
                 <ImageView
                     android:id="@+id/dress_view"
+                    android:contentDescription="@string/cloth"
                     android:src="@drawable/dress_avatar1"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
 
                 <ImageView
                     android:id="@+id/hair_view"
+                    android:contentDescription="@string/hair"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/hair1"
@@ -160,6 +183,7 @@
 
                 <ImageView
                     android:id="@+id/eye_view"
+                    android:contentDescription="@string/eye"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/eyes1"
@@ -179,10 +203,12 @@
 
     <ImageView
         android:id="@+id/continueButtonAvatar"
+        android:contentDescription="@string/continue_desc"
         android:layout_width="@dimen/continue_width"
         android:layout_height="@dimen/continue_height"
         android:layout_alignParentBottom="true"
         android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
         android:layout_marginBottom="@dimen/continue_marginBottom"
         android:alpha="0.9"
         android:background="@drawable/continue_button"

--- a/PowerUp/app/src/main/res/layout/activity_final_avatar.xml
+++ b/PowerUp/app/src/main/res/layout/activity_final_avatar.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/store"
+    android:orientation="vertical">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"></LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="10"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/final_avatar_marginTop"
+                android:gravity="center"
+                android:textSize="@dimen/final_avatar_textSize"
+                android:textStyle="bold"
+                android:textColor="@color/final_avatar_text"
+                android:text="@string/final_avatar_confirm"
+                />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="20"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="2.3"></LinearLayout>
+
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/skin_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/skin1"
+                    android:scaleType="fitXY"/>
+
+                <ImageView
+                    android:id="@+id/dress_view"
+                    android:src="@drawable/dress_avatar1"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" />
+
+                <ImageView
+                    android:id="@+id/hair_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/hair1"
+                    android:scaleType="fitXY"/>
+
+                <ImageView
+                    android:id="@+id/eye_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/eyes1"
+                    android:scaleType="fitXY"/>
+
+            </FrameLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="2.3"></LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/continueButton"
+        android:layout_width="@dimen/continue_width"
+        android:layout_height="@dimen/continue_height"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true"
+        android:layout_marginBottom="@dimen/continue_marginBottom"
+        android:alpha="0.9"
+        android:background="@drawable/continue_button"
+        android:scaleType="fitXY" />
+
+    <ImageView
+        android:id="@+id/backButton"
+        android:layout_width="@dimen/back_width"
+        android:layout_height="@dimen/back_height"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true"
+        android:layout_marginTop="@dimen/back_marginTop"
+        android:layout_marginLeft="@dimen/back_marginLeft"
+        android:alpha="0.9"
+        android:background="@drawable/arrow_left"
+        android:scaleType="fitXY" />
+
+</RelativeLayout>

--- a/PowerUp/app/src/main/res/layout/activity_final_avatar.xml
+++ b/PowerUp/app/src/main/res/layout/activity_final_avatar.xml
@@ -12,11 +12,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"></LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
             android:layout_weight="10"
             android:orientation="horizontal">
 
@@ -27,7 +22,7 @@
                 android:gravity="center"
                 android:textSize="@dimen/final_avatar_textSize"
                 android:textStyle="bold"
-                android:textColor="@color/final_avatar_text"
+                android:textColor="@color/powerup_blue_green"
                 android:text="@string/final_avatar_confirm"
                 />
 
@@ -37,7 +32,8 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="20"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:baselineAligned="false">
 
             <LinearLayout
                 android:layout_width="0dp"
@@ -51,6 +47,7 @@
 
                 <ImageView
                     android:id="@+id/skin_view"
+                    android:contentDescription="@string/skin"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/skin1"
@@ -58,12 +55,14 @@
 
                 <ImageView
                     android:id="@+id/dress_view"
+                    android:contentDescription="@string/cloth"
                     android:src="@drawable/dress_avatar1"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
 
                 <ImageView
                     android:id="@+id/hair_view"
+                    android:contentDescription="@string/hair"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/hair1"
@@ -71,6 +70,7 @@
 
                 <ImageView
                     android:id="@+id/eye_view"
+                    android:contentDescription="@string/eye"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:src="@drawable/eyes1"
@@ -89,9 +89,11 @@
 
     <ImageView
         android:id="@+id/continueButton"
+        android:contentDescription="@string/continue_desc"
         android:layout_width="@dimen/continue_width"
         android:layout_height="@dimen/continue_height"
         android:layout_alignParentBottom="true"
+        android:layout_alignParentEnd="true"
         android:layout_alignParentRight="true"
         android:layout_marginBottom="@dimen/continue_marginBottom"
         android:alpha="0.9"
@@ -100,12 +102,15 @@
 
     <ImageView
         android:id="@+id/backButton"
+        android:contentDescription="@string/back_desc"
         android:layout_width="@dimen/back_width"
         android:layout_height="@dimen/back_height"
         android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:layout_marginTop="@dimen/back_marginTop"
         android:layout_marginLeft="@dimen/back_marginLeft"
+        android:layout_marginStart="@dimen/back_marginLeft"
         android:alpha="0.9"
         android:background="@drawable/arrow_left"
         android:scaleType="fitXY" />

--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -238,4 +238,10 @@
     <dimen name="replay_marginTop">400dp</dimen>
     <dimen name="replay_marginLeft">180dp</dimen>
     <dimen name="hair_button_marginLeft">100dp</dimen>
+    <dimen name="final_avatar_marginTop">60dp</dimen>
+    <dimen name="final_avatar_textSize">20sp</dimen>
+    <dimen name="back_width">36dp</dimen>
+    <dimen name="back_height">36dp</dimen>
+    <dimen name="back_marginTop">10dp</dimen>
+    <dimen name="back_marginLeft">10dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values-normal/dimens.xml
+++ b/PowerUp/app/src/main/res/values-normal/dimens.xml
@@ -60,4 +60,10 @@
     <dimen name="replay_marginTop">180dp</dimen>
     <dimen name="replay_marginLeft">110dp</dimen>
     <dimen name="hair_button_marginLeft">100dp</dimen>
+    <dimen name="final_avatar_marginTop">60dp</dimen>
+    <dimen name="final_avatar_textSize">20sp</dimen>
+    <dimen name="back_width">36dp</dimen>
+    <dimen name="back_height">36dp</dimen>
+    <dimen name="back_marginTop">10dp</dimen>
+    <dimen name="back_marginLeft">10dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values/color.xml
+++ b/PowerUp/app/src/main/res/values/color.xml
@@ -11,4 +11,5 @@
     <color name="correct_answer">#69FF6E</color>
     <color name="wrong_answer">#FF6969</color>
     <color name="score_text">#6EBFE1</color>
+    <color name="final_avatar_text">#5E95AD</color>
 </resources>

--- a/PowerUp/app/src/main/res/values/color.xml
+++ b/PowerUp/app/src/main/res/values/color.xml
@@ -11,5 +11,4 @@
     <color name="correct_answer">#69FF6E</color>
     <color name="wrong_answer">#FF6969</color>
     <color name="score_text">#6EBFE1</color>
-    <color name="final_avatar_text">#5E95AD</color>
 </resources>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -68,4 +68,18 @@
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
     <string name="final_avatar_confirm">This is your final avatar! Press continue to start your Journey...</string>
+    <string name="continue_desc">Continue button</string>
+    <string name="back_desc">Back button</string>
+    <string name="skin_left_button">Left arrow button for skin</string>
+    <string name="skin_right_button">Right arrow button for skin</string>
+    <string name="eye_left_button">Left arrow button for eye</string>
+    <string name="eye_right_button">Right arrow button for eye</string>
+    <string name="cloth_left_button">Left arrow button for cloth</string>
+    <string name="cloth_right_button">Right arrow button for cloth</string>
+    <string name="hair_left_button">Left arrow button for hair</string>
+    <string name="hair_right_button">Right arrow button for hair</string>
+    <string name="skin_text">Skin</string>
+    <string name="eye_text">Eyes</string>
+    <string name="cloth_text">Clothes</string>
+    <string name="hair_text">Hair</string>
 </resources>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="final_avatar_confirm">This is your final avatar! Press continue to start your Journey...</string>
 </resources>


### PR DESCRIPTION
### Description
PowerUp Android currently does not have a final avatar screen, unlike the iOS version. I have created a screen displaying the user's final avatar that has the same background as the avatar room and similar functionalities/UI as the iOS final avatar screen.

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
A video of the new feature can be seen here: https://www.flickr.com/photos/156368229@N03/27604897199/in/photolist-J4mjcr-Et83sy
Steps to Reproduce:
1. Press "new game" button in StartActivity and create new avatar
2. Customize avatar
3. Press "continue" button
4. Press "back" button
5. Customize avatar again
6. Press "continue" button and advance with the game.

### Checklist:

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials
- [X] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
