### PR TITLE
Program GCI: Fix Scene Completion

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -32,7 +32,10 @@ import powerup.systers.com.minesweeper.MinesweeperSessionManager;
 import powerup.systers.com.minesweeper.MinesweeperTutorials;
 import powerup.systers.com.powerup.PowerUpUtils;
 import powerup.systers.com.sink_to_swim_game.SinkToSwimGame;
+import powerup.systers.com.sink_to_swim_game.SinkToSwimSessionManager;
 import powerup.systers.com.sink_to_swim_game.SinkToSwimTutorials;
+import powerup.systers.com.vocab_match_game.VocabMatchGameActivity;
+import powerup.systers.com.vocab_match_game.VocabMatchSessionManager;
 import powerup.systers.com.vocab_match_game.VocabMatchTutorials;
 
 @SuppressLint("NewApi")
@@ -58,6 +61,10 @@ public class GameActivity extends Activity {
 
         if (new MinesweeperSessionManager(this).isMinesweeperOpened()) {
             startActivity(new Intent(GameActivity.this, MinesweeperGameActivity.class));
+        } else if (new VocabMatchSessionManager(this).isVocabMatchOpened()) { //if vocabmatch game was left incomplete
+            startActivity(new Intent(this, VocabMatchGameActivity.class));
+        } else if (new SinkToSwimSessionManager(this).isSinkToSwimOpened()) { //if sinktoswim game was left incomplete
+            startActivity(new Intent(this, SinkToSwimGame.class));
         }
         if (savedInstanceState != null) {
             isStateChanged = true;
@@ -238,8 +245,10 @@ public class GameActivity extends Activity {
                     new MinesweeperSessionManager(this).saveMinesweeperOpenedStatus(true); //marks minesweeper game as opened and incompleted
                     startActivity(new Intent(GameActivity.this, MinesweeperTutorials.class));
                 } else if (type == -2) {
+                    new SinkToSwimSessionManager(this).saveSinkToSwimOpenedStatus(true);
                     startActivity(new Intent(GameActivity.this, SinkToSwimTutorials.class));
                 } else if (type == -3) {
+                    new VocabMatchSessionManager(this).saveVocabMatchOpenedStatus(true);
                     startActivity(new Intent(GameActivity.this, VocabMatchTutorials.class));
                 }
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -18,6 +18,10 @@ import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.minesweeper.MinesweeperGameActivity;
 import powerup.systers.com.minesweeper.MinesweeperSessionManager;
 import powerup.systers.com.powerup.PowerUpUtils;
+import powerup.systers.com.sink_to_swim_game.SinkToSwimGame;
+import powerup.systers.com.sink_to_swim_game.SinkToSwimSessionManager;
+import powerup.systers.com.vocab_match_game.VocabMatchGameActivity;
+import powerup.systers.com.vocab_match_game.VocabMatchSessionManager;
 
 public class MapActivity extends Activity {
 
@@ -31,6 +35,10 @@ public class MapActivity extends Activity {
                 startActivityForResult(new Intent(MapActivity.this, GameActivity.class), 0);
             } else if (new MinesweeperSessionManager(MapActivity.this).isMinesweeperOpened()) { //if minesweeper game was left incomplete
                 startActivity(new Intent(MapActivity.this, MinesweeperGameActivity.class));
+            } else if (new VocabMatchSessionManager(MapActivity.this).isVocabMatchOpened()) { //if vocabmatch game was left incomplete
+                startActivity(new Intent(MapActivity.this, VocabMatchGameActivity.class));
+            } else if (new SinkToSwimSessionManager(MapActivity.this).isSinkToSwimOpened()) { //if sinktoswim game was left incomplete
+                startActivity(new Intent(MapActivity.this, SinkToSwimGame.class));
             } else {
                 Intent intent = new Intent(MapActivity.this, ScenarioOverActivity.class);
                 intent.putExtra(PowerUpUtils.SOURCE,PowerUpUtils.MAP);

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -23,6 +23,10 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.Toast;
 
+import powerup.systers.com.minesweeper.MinesweeperSessionManager;
+import powerup.systers.com.sink_to_swim_game.SinkToSwimSessionManager;
+import powerup.systers.com.vocab_match_game.VocabMatchSessionManager;
+
 public class StartActivity extends Activity {
 
     private SharedPreferences preferences;
@@ -49,6 +53,9 @@ public class StartActivity extends Activity {
                 builder.setPositiveButton(getString(R.string.start_confirm_message), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
+                        new MinesweeperSessionManager(StartActivity.this).saveMinesweeperOpenedStatus(false);
+                        new VocabMatchSessionManager(StartActivity.this).saveVocabMatchOpenedStatus(false);
+                        new SinkToSwimSessionManager(StartActivity.this).saveSinkToSwimOpenedStatus(false);
                     }
                 });
                 builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
@@ -16,6 +16,7 @@ public class SinkToSwimEndActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_sink_to_swim_end);
+        new SinkToSwimSessionManager(this).saveSinkToSwimOpenedStatus(false);
         Intent intent = getIntent();
         int wrongAnswers= intent.getExtras().getInt(PowerUpUtils.WRONG_ANSWER);
         int correctAnswers= intent.getExtras().getInt(PowerUpUtils.CORRECT_ANSWERS);

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimSessionManager.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimSessionManager.java
@@ -1,0 +1,43 @@
+package powerup.systers.com.sink_to_swim_game;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Created by Aryaman21 on 31-12-2017.
+ */
+
+public class SinkToSwimSessionManager {
+    
+    private final String PREF_NAME = "SINKTOSWIM_PREFERENCE";
+    private final int PRIVATE_MODE = 0;
+    private final String GAME_OPENED = "IS_SINKTOSWIM_OPENED";
+
+    SharedPreferences pref;
+    Context context;
+    SharedPreferences.Editor editor;
+
+    /**
+     * @param context - context of the calling activity
+     * @desc Returns the object of SessionManager through which session changes can be made
+     */
+    public SinkToSwimSessionManager(Context context) {
+        this.context = context;
+        pref = context.getSharedPreferences(PREF_NAME, PRIVATE_MODE);
+        editor = pref.edit();
+    }
+
+    /**
+     * @return true if app was closed without completing the sinktoswim game
+     * @desc used to know if sinktoswim game was being played when user last left the app
+     */
+    public boolean isSinkToSwimOpened() {
+        return pref.getBoolean(GAME_OPENED, false);
+    }
+
+    public void saveSinkToSwimOpenedStatus(boolean isOpened) {
+        editor.putBoolean(GAME_OPENED, isOpened);
+        editor.clear();
+        editor.commit();
+    }
+}

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
@@ -19,6 +19,7 @@ public class VocabMatchEndActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_vocab_match_end);
+        new VocabMatchSessionManager(this).saveVocabMatchOpenedStatus(false);
         Intent intent = getIntent();
         int score = intent.getExtras().getInt(PowerUpUtils.SCORE);
         int correctAnswers= score;

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchSessionManager.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchSessionManager.java
@@ -1,0 +1,43 @@
+package powerup.systers.com.vocab_match_game;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Created by Aryaman21 on 31-12-2017.
+ */
+
+public class VocabMatchSessionManager {
+
+    private final String PREF_NAME = "VOCABMATCH_PREFERENCE";
+    private final int PRIVATE_MODE = 0;
+    private final String GAME_OPENED = "IS_VOCABMATCH_OPENED";
+
+    SharedPreferences pref;
+    Context context;
+    SharedPreferences.Editor editor;
+
+    /**
+     * @param context - context of the calling activity
+     * @desc Returns the object of SessionManager through which session changes can be made
+     */
+    public VocabMatchSessionManager(Context context) {
+        this.context = context;
+        pref = context.getSharedPreferences(PREF_NAME, PRIVATE_MODE);
+        editor = pref.edit();
+    }
+
+    /**
+     * @return true if app was closed without completing the sinktoswim game
+     * @desc used to know if vocabmatch game was being played when user last left the app
+     */
+    public boolean isVocabMatchOpened() {
+        return pref.getBoolean(GAME_OPENED, false);
+    }
+
+    public void saveVocabMatchOpenedStatus(boolean isOpened) {
+        editor.putBoolean(GAME_OPENED, isOpened);
+        editor.clear();
+        editor.commit();
+    }
+}


### PR DESCRIPTION
### Description
Pull request as part of the GCI'17 task 'Solve Issue: Scene Completed after conversation irrespective of completion of mini-game #499 on PowerUp Android'.

Fixes #499

### Changes Implemented

#### GameActivity and MapActivity
- Check for the previous instance of MineSweeperGame in the OnCreate() method was implemented in the MapActivity instead.
- Whenever a user has a previous minigame running and clicks on one of the scene options from the MapActivity, the minigame is restarted to continue progress.
#### Creation of SessionManagers
- VocabMatchSessionManager and SinkToSwimSessionManager classes were made to mimic the implemetation of MineSweeperSessionManager as @codingblazer had implemented. 
- Both the activities can also be used to store additional MiniGame details if needed, and can be used to implement a "Resume Game dialog alert feature", this would ask the user when he is about to start his MiniGame that whether he wants to replay the MiniGame or start fresh.
#### StartActivity
- NewGameButton positive confirmation resets the previous mini game status to false, invoking the start of the game from the beginning. 
