### PR TITLE
Program GCI: Adding Marcello Text

### DIFF
--- a/PowerUp/app/src/main/res/layout-land/game_activity.xml
+++ b/PowerUp/app/src/main/res/layout-land/game_activity.xml
@@ -42,6 +42,17 @@
         android:layout_alignParentTop="true"
         android:src="@drawable/marco" />
 
+    <TextView
+        android:id="@+id/character_description"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/character_description_text_size"
+        android:textColor="@color/powerup_black"
+        android:text="@string/character_description_text"
+        android:textStyle="bold"
+        android:layout_below="@id/askerImageView"
+        android:layout_toLeftOf="@id/continueButtonGoesToMap"
+        android:layout_toStartOf="@id/continueButtonGoesToMap"/>
 
 
     <FrameLayout

--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -238,4 +238,5 @@
     <dimen name="replay_marginTop">400dp</dimen>
     <dimen name="replay_marginLeft">180dp</dimen>
     <dimen name="hair_button_marginLeft">100dp</dimen>
+    <dimen name="character_description_text_size">18sp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="character_description_text">Marcello</string>
 </resources>


### PR DESCRIPTION
### Description
Pull Request as part of the GCI task 'PowerUp Android: Add "Marcello" text in scenarios (like in iOS version)'

Fixes #554 

### Type of Change:
- Code
- User Interface

### Changes
- Added Marcello Text in the GameActivity
- Text changes to Dr. Bulma and Mom for Hospital and Library Scenario respectively.

### Screenshot
![device-2018-01-01-171951](https://user-images.githubusercontent.com/19228432/34467446-1a760560-ef18-11e7-8a8b-aa0e5a2a691d.png)
- Pixel (1920x1080)
![pixel](https://user-images.githubusercontent.com/19228432/34469405-3029ed6e-ef44-11e7-8ed5-d8ca972a0e7b.png)
- Pixel XL (2560x1440)
![pixel xl](https://user-images.githubusercontent.com/19228432/34469407-306dbfda-ef44-11e7-887e-bd847f6328d9.png)
- Galaxy Nexus (1280x720)
![galaxy nexus](https://user-images.githubusercontent.com/19228432/34469408-30bf0250-ef44-11e7-96ec-70cc5577b645.png)
- Nexus One (800x480)
![nexus one](https://user-images.githubusercontent.com/19228432/34469471-a8cff7a8-ef45-11e7-9d5e-c1abaee9f437.png)