### PR TITLE
Remove lint warnings

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/db/AbstractDbAdapter.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/db/AbstractDbAdapter.java
@@ -15,6 +15,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 
 public abstract class AbstractDbAdapter {
 
@@ -120,7 +121,7 @@ public abstract class AbstractDbAdapter {
                 throw new Error(
                         "Incorrect Answer CSV Format! Use AID, QID, ADes,"
                                 + "NextID, Points at line: "
-                                + rowData.toString());
+                                + Arrays.toString(rowData));
             }
         }
 
@@ -145,7 +146,7 @@ public abstract class AbstractDbAdapter {
             } else {
                 throw new Error("Incorrect Scenario CSV Format! Use ID,"
                         + "ScenarioName, Timestamp, Asker, Avatar, FirstQID,"
-                        + " NextScenarioID at line: " + rowData.toString());
+                        + " NextScenarioID at line: " + Arrays.toString(rowData));
             }
         }
 
@@ -164,7 +165,7 @@ public abstract class AbstractDbAdapter {
                 db.insert(PowerUpContract.ClothesEntry.TABLE_NAME, null, values);
             } else {
                 throw new Error("Incorrect Clothes CSV Format! Use ID,"
-                        + "ClothName, Points" + rowData.toString());
+                        + "ClothName, Points" + Arrays.toString(rowData));
             }
         }
 
@@ -183,7 +184,7 @@ public abstract class AbstractDbAdapter {
                 db.insert(PowerUpContract.HairEntry.TABLE_NAME, null, values);
             } else {
                 throw new Error("Incorrect Hair CSV Format! Use ID,"
-                        + "HairName, Points" + rowData.toString());
+                        + "HairName, Points" + Arrays.toString(rowData));
             }
         }
 
@@ -202,7 +203,7 @@ public abstract class AbstractDbAdapter {
                 db.insert(PowerUpContract.AccessoryEntry.TABLE_NAME, null, values);
             } else {
                 throw new Error("Incorrect Accessory CSV Format! Use ID,"
-                        + "AccessoryName, Points" + rowData.toString());
+                        + "AccessoryName, Points" + Arrays.toString(rowData));
             }
         }
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
@@ -189,7 +189,7 @@ public class SinkToSwimGame extends AppCompatActivity {
     public void answerChosen(View view) {
         setButtonsEnabled(false);
         if (view == findViewById(R.id.true_option)) {
-            if (PowerUpUtils.SWIM_SINK_QUESTION_ANSWERS[curQuestion][1] == "T") {
+            if (PowerUpUtils.SWIM_SINK_QUESTION_ANSWERS[curQuestion][1].equals("T")) {
                 score += 1;
                 correctAnswers++;
                 bringPointerAndAvatarUp();
@@ -199,7 +199,7 @@ public class SinkToSwimGame extends AppCompatActivity {
                 wrongAnswers++;
             }
         } else if (view == findViewById(R.id.false_option)) {
-            if (PowerUpUtils.SWIM_SINK_QUESTION_ANSWERS[curQuestion][1] == "F") {
+            if (PowerUpUtils.SWIM_SINK_QUESTION_ANSWERS[curQuestion][1].equals("F")) {
                 score += 1;
                 correctAnswers++;
                 bringPointerAndAvatarUp();


### PR DESCRIPTION
### Description
Remove lint warnings related to "Call to 'toString()' on array" and "String comparison using '==', instead of 'equals()' "

Fixes #588

### Type of Change:
- Code
- Quality Assurance
- Bug fix (non-breaking change which fixes an issue)



### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials 
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
