### PR TITLE
Program GCI: Include a Scenario Over Screen after Library scenario

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -63,7 +63,11 @@ public class ScenarioOverActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 new GameActivity().gameActivityInstance.finish();
-                startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+                if (getIntent().getBooleanExtra(PowerUpUtils.IS_FINAL_SCENARIO_EXTRA, false)) {
+                    startActivity(new Intent(ScenarioOverActivity.this, GameOverActivity.class));
+                } else {
+                    startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+                }
             }
         });
         if (getIntent().getExtras()!=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE))){

--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -25,6 +25,7 @@ public class PowerUpUtils {
     public static final String ID_REFERENCE = "powerup.systers.com.powerup:id/imageView";
     public static final String ID_REF = "powerup.systers.com:id/imageView";
     public static final String MINESWEEP_PREVIOUS_SCENARIO = "School";
+    public static final String IS_FINAL_SCENARIO_EXTRA = "IS_FINAL_SCENARIO";
 
     public static final int[] ROUNDS_FAILURE_PERCENTAGES = {18, 20, 25};
     public static final int[] ROUND_BACKGROUNDS = {R.drawable.minesweeper_condom_background, R.drawable.minesweeper_condom_background, R.drawable.minesweeper_condom_background};

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
@@ -8,6 +8,7 @@ import android.widget.TextView;
 
 import powerup.systers.com.GameOverActivity;
 import powerup.systers.com.R;
+import powerup.systers.com.ScenarioOverActivity;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class SinkToSwimEndActivity extends AppCompatActivity {
@@ -29,7 +30,8 @@ public class SinkToSwimEndActivity extends AppCompatActivity {
     }
 
     public void continuePressed(View view){
-        Intent intent = new Intent(SinkToSwimEndActivity.this, GameOverActivity.class);
+        Intent intent = new Intent(SinkToSwimEndActivity.this, ScenarioOverActivity.class);
+        intent.putExtra(PowerUpUtils.IS_FINAL_SCENARIO_EXTRA, true);
         finish();
         startActivityForResult(intent, 0);
     }


### PR DESCRIPTION
 I used the existing ScenarioOver screen, just add an extra intent parameter to handle final scenario continue button navigation.
![screenshot_2018-01-04-16-40-58-839_powerup systers com powerup 1](https://user-images.githubusercontent.com/18180597/34557872-e51fb94c-f165-11e7-8a52-3fb82057e416.png)
