### PR TITLE
Program GCI: Included Total Points Dialog in ScenarioOverActivity

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -213,6 +213,7 @@ public class GameActivity extends Activity {
                 public void onClick(View v) {
                     // Incase the user move back to map in between a running
                     // Scenario.
+                    PowerUpUtils.SHOW_DIALOG=false;
                     SessionHistory.totalPoints -= SessionHistory.currScenePoints;
                     goToMap.setClickable(false);
                     Intent intent = new Intent(GameActivity.this, MapActivity.class);

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -8,14 +8,28 @@ package powerup.systers.com;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.media.tv.TvInputService;
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.DialogTitle;
+import android.util.DisplayMetrics;
+import android.view.Gravity;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import com.akexorcist.roundcornerprogressbar.IconRoundCornerProgressBar;
 
@@ -51,6 +65,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
         mapButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                PowerUpUtils.SHOW_DIALOG=false;
                 finish();
                 startActivity(new Intent(ScenarioOverActivity.this, MapActivity.class));
             }
@@ -62,6 +77,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
         continueButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                PowerUpUtils.SHOW_DIALOG=true;
                 new GameActivity().gameActivityInstance.finish();
                 startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
             }
@@ -75,6 +91,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
         replayButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                PowerUpUtils.SHOW_DIALOG=true;
                 SessionHistory.currSessionID = SessionHistory.prevSessionID;
                 SessionHistory.totalPoints -= SessionHistory.currScenePoints;
                 SessionHistory.currScenePoints = 0;
@@ -87,6 +104,51 @@ public class ScenarioOverActivity extends AppCompatActivity {
                 startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
             }
         });
+
+        if (PowerUpUtils.SHOW_DIALOG || SessionHistory.prevSessionID==SessionHistory.currSessionID) {
+            String overTitleMessage = getResources().getString(R.string.over_title_message);
+            String overDismissMessage = getResources().getString(R.string.over_dismiss_message);
+            String overDialogMessage = getResources().getString(R.string.over_dialog_start_message) + " ";
+            overDialogMessage += SessionHistory.currScenePoints + " " + getResources().getString(R.string.over_dialog_end_message);
+
+            DisplayMetrics displayMetrics = new DisplayMetrics();
+            getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+            int dialogHeight = (int) (displayMetrics.heightPixels * 0.5);
+            int dialogWidth = (int) (displayMetrics.widthPixels * 0.43 );
+
+            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(ScenarioOverActivity.this);
+            alertDialogBuilder
+                    .setTitle(overTitleMessage)
+                    .setMessage(overDialogMessage)
+                    .setCancelable(false)
+                    .setNeutralButton(overDismissMessage, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            dialog.dismiss();
+                        }
+                    });
+
+            TextView titleText = new TextView(this);
+            titleText.setGravity(Gravity.CENTER_HORIZONTAL);
+            titleText.setText(overTitleMessage);
+            titleText.setTextSize(20);
+            titleText.setTypeface(null, Typeface.BOLD);
+            titleText.setPadding(5,20,5,5);
+            titleText.setTextColor(getResources().getColor(R.color.powerup_black));
+            alertDialogBuilder.setCustomTitle(titleText);
+            final AlertDialog alert = alertDialogBuilder.create();
+
+            alert.show();
+            alert.getWindow().setLayout(dialogWidth,dialogHeight);
+
+            TextView messageText = (TextView) alert.findViewById(android.R.id.message);
+            messageText.setPadding(5,10,5,5);
+            messageText.setGravity(Gravity.CENTER);
+
+            final Button dismissButton = alert.getButton(AlertDialog.BUTTON_NEUTRAL);
+            LinearLayout.LayoutParams dismissButtonLL = (LinearLayout.LayoutParams) dismissButton.getLayoutParams();
+            dismissButtonLL.width = ViewGroup.LayoutParams.MATCH_PARENT;
+            dismissButton.setLayoutParams(dismissButtonLL);
+        }
     }
 
     /**
@@ -94,6 +156,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
      */
     @Override
     public void onBackPressed() {
+        PowerUpUtils.SHOW_DIALOG=true;
         super.onBackPressed();
         new GameActivity().gameActivityInstance.finish();
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -13,6 +13,7 @@ public class PowerUpUtils {
     public static final int MAXIMUM_FLIPS_ALLOWED = 5;
     public static final int RED_BANNER = 1;
     public static final int GREEN_BANNER = 0;
+    public static boolean SHOW_DIALOG = true;
 
     public static final String SCORE = "score";
     public static final String CORRECT_ANSWERS = "correct";

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,8 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="over_title_message">Hooray!</string>
+    <string name="over_dialog_start_message">You gained</string>
+    <string name="over_dialog_end_message">Karma points!</string>
+    <string name="over_dismiss_message">OK</string>
 </resources>


### PR DESCRIPTION
### Description
Displays a Dialog in ScenarioOverActivity to fix inconsistency between PowerUp Android and PowerUp iOS. Fixes #730. Below is a photo of the fix. The dialog box's size changes based on the screen size to make sure there is not extra white space. The Dialog Text is centered, and if a scene is replayed, the dialog box no longer shows.

<img width="1280" alt="screen shot 2018-01-05 at 9 09 42 pm" src="https://user-images.githubusercontent.com/23027638/34610602-d3ae9528-f25c-11e7-8c1e-b9ed4244d292.png">

### Type of Change:
- Code
- User Interface

### How Has This Been Tested?
I ran the app on my phone to see if the fix worked. See screenshot above for results.

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
  