### PR TITLE
Program: GCI Added Product Flavors

### DIFF
--- a/PowerUp/app/build.gradle
+++ b/PowerUp/app/build.gradle
@@ -22,6 +22,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    flavorDimensions "default"
+    productFlavors {
+        free {
+            applicationIdSuffix '.free'
+            versionNameSuffix '-free'
+        }
+        paid {
+            applicationIdSuffix '.paid'
+            versionNameSuffix '-paid'
+        }
+    }
 }
 
 dependencies {

--- a/PowerUp/app/src/free/res/layout/activity_main.xml
+++ b/PowerUp/app/src/free/res/layout/activity_main.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/start_screen_background"
+    android:orientation="vertical"
+    tools:context="powerup.systers.com.StartActivity">
+
+    <Button
+        android:layout_weight="0.8"
+        android:id="@+id/aboutButtonMain"
+        android:layout_width="@dimen/about_button_width"
+        android:layout_height="0dp"
+        android:alpha="1"
+        android:stateListAnimator="@null"
+        android:background="@android:color/white"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="4">
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="2.6"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <Button
+            android:id="@+id/newUserButtonFirstPage"
+            android:layout_width="@dimen/new_user_button_width"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:alpha="0"/>
+        <Button
+            android:id="@+id/startButtonMain"
+            android:layout_width="@dimen/start_button_width"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:textStyle="bold"
+            android:alpha="0"/>
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
I have added the product flavors for the app. In the freeDebug version the About button is hidden, and in the paidDebug version the app remains as is with the About button available to users. The screenshots are attached.

freeDebug:
![powerup_freedebug 1](https://user-images.githubusercontent.com/30957432/34641774-cbb75c3c-f311-11e7-9886-d93b214520d3.png)

paidDebug:
![powerup_paiddebug 1](https://user-images.githubusercontent.com/30957432/34641782-ead4cabe-f311-11e7-9071-1e83ea03fa15.png)

Build Variants Window:
![build_variants](https://user-images.githubusercontent.com/30957432/34641790-0755df70-f312-11e7-9600-66964355ad2b.PNG)

