### PR TITLE
Fix issues in PULL_REQUEST_TEMPLATE

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Describe the tests you ran to verify your changes. Provide instructions or GIFs 
 ### Checklist:
 **Delete irrelevant options.**
 
-- [ ] My PR follows the style guidelines of this project
+- [ ] My PR follows the style guidelines for this project
 - [ ] I have performed a self-review of my own code or materials
 - [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
@@ -34,7 +34,7 @@ Describe the tests you ran to verify your changes. Provide instructions or GIFs 
 
 **Code/Quality Assurance Only**
 - [ ] My changes generate no new warnings 
-- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
+- [ ] My PR currently doesn't break something (fix or feature that would cause existing functionality to not work as expected)
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been published in downstream modules


### PR DESCRIPTION
### Description
Two issues in `PULL_REQUEST_TEMPLATE` that my PR fixes:
1. A grammar mistake(on line 29) which says that there are style guidelines _"of"_ the project, which should be _"for"_ the project.
2. On line 37, the **checklist** says that it does break something. If the changes don't break anything, the **checklist** would be left unchecked. Which brings a contradiction: a **checklist** is made to have all the elements checked if the work is perfect, which, in this case, would not happen.


- Quality Assurance
- Documentation

### Checklist:
- [x] My PR follows the style guidelines for this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings 