### PR TITLE
Program GCI: Added a not enough points dialog for non-purchasable items in StoreActivity

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
@@ -1,12 +1,18 @@
 package powerup.systers.com;
 
 import android.annotation.TargetApi;
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.os.Build;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,6 +22,7 @@ import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.GridView;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.w3c.dom.Text;
@@ -305,33 +312,77 @@ public class StoreActivity extends AppCompatActivity {
 
                         TextView itemPoints = (TextView) v.findViewById(R.id.item_points);
                         int index = calculatePosition(position)+1;
-                        if (storeItemTypeindex == 0) { //hair
-                            setAvatarHair(index);
-                            if (getmDbHandler().getPurchasedHair(index) == 0){
-                                SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
-                                karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+                        if (getPurchasedStatus(index) == 0 && Integer.parseInt(itemPoints.getText().toString()) > SessionHistory.totalPoints) {
+                            String pointsTitleMessage = getResources().getString(R.string.not_enough_points_title_message);
+                            String pointsDismissMessage = getResources().getString(R.string.not_enough_points_dismiss_message);
+                            String pointsDialogMessage = getResources().getString(R.string.not_enough_points_dialog_message);
 
-                                getmDbHandler().setPurchasedHair(index);
-                            }
+                            int dialogHeight = (int) (screenHeight * 0.5);
+                            int dialogWidth = (int) (screenWidth * 0.43);
 
-                        } else if (storeItemTypeindex == 1) { //clothes
-                            setAvatarClothes(index);
-                            if (getmDbHandler().getPurchasedClothes(index) == 0){
-                                SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
-                                karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
-                                getmDbHandler().setPurchasedClothes(index);
-                            }
+                            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(StoreActivity.this);
+                            alertDialogBuilder
+                                    .setTitle(pointsTitleMessage)
+                                    .setMessage(pointsDialogMessage)
+                                    .setCancelable(false)
+                                    .setNeutralButton(pointsDismissMessage, new DialogInterface.OnClickListener() {
+                                        public void onClick(DialogInterface dialog, int id) {
+                                            dialog.dismiss();
+                                        }
+                                    });
+                            int DIALOG_PADDING_5=PowerUpUtils.DIALOG_PADDING_5;
 
-                        } else if (storeItemTypeindex == 2) { //accessories
-                            setAvatarAccessories(index);
-                            if (getmDbHandler().getPurchasedAccessories(index) == 0){
-                                SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
-                                karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
-                                getmDbHandler().setPurchasedAccessories(index);
+                            TextView titleText = new TextView(context);
+                            titleText.setGravity(Gravity.CENTER_HORIZONTAL);
+                            titleText.setText(pointsTitleMessage);
+                            titleText.setTextSize(PowerUpUtils.DIALOG_LARGE_TEXT);
+                            titleText.setTypeface(null, Typeface.BOLD);
+                            titleText.setPadding(DIALOG_PADDING_5, DIALOG_PADDING_5, DIALOG_PADDING_5, PowerUpUtils.DIALOG_PADDING_0);
+                            titleText.setTextColor(getResources().getColor(R.color.powerup_black));
+                            alertDialogBuilder.setCustomTitle(titleText);
+                            final AlertDialog alert = alertDialogBuilder.create();
+
+                            alert.show();
+                            alert.getWindow().setLayout(dialogWidth, dialogHeight);
+                            TextView messageText = (TextView) alert.findViewById(android.R.id.message);
+                            messageText.setTextSize(PowerUpUtils.DIALOG_SMALL_TEXT);
+                            messageText.setPadding(DIALOG_PADDING_5, DIALOG_PADDING_5, DIALOG_PADDING_5, DIALOG_PADDING_5);
+                            messageText.setGravity(Gravity.CENTER);
+
+                            final Button dismissButton = alert.getButton(AlertDialog.BUTTON_NEUTRAL);
+                            dismissButton.setTextSize(PowerUpUtils.DIALOG_SMALL_TEXT);
+                            LinearLayout.LayoutParams dismissButtonLL = (LinearLayout.LayoutParams) dismissButton.getLayoutParams();
+                            dismissButtonLL.width = ViewGroup.LayoutParams.MATCH_PARENT;
+                            dismissButton.setLayoutParams(dismissButtonLL);
+                        } else{
+                            if (storeItemTypeindex == 0) { //hair
+                                setAvatarHair(index);
+                                if (getmDbHandler().getPurchasedHair(index) == 0){
+                                    SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
+                                    karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+
+                                    getmDbHandler().setPurchasedHair(index);
+                                }
+
+                            } else if (storeItemTypeindex == 1) { //clothes
+                                setAvatarClothes(index);
+                                if (getmDbHandler().getPurchasedClothes(index) == 0){
+                                    SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
+                                    karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+                                    getmDbHandler().setPurchasedClothes(index);
+                                }
+
+                            } else if (storeItemTypeindex == 2) { //accessories
+                                setAvatarAccessories(index);
+                                if (getmDbHandler().getPurchasedAccessories(index) == 0){
+                                    SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
+                                    karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+                                    getmDbHandler().setPurchasedAccessories(index);
+                                }
                             }
+                            adapter.refresh(adapter.storeItems); // will update change the background if any is not available
+
                         }
-                        adapter.refresh(adapter.storeItems); // will update change the background if any is not available
-
                     }
                 }
             });
@@ -353,7 +404,7 @@ public class StoreActivity extends AppCompatActivity {
 
                 } else { //can't be bought
                     storeItem.setBackground(getResources().getDrawable(R.drawable.unavailable_item));
-                    storeItem.setEnabled(false);
+                    storeItem.setEnabled(true);
                 }
             }
             return storeItem;

--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -13,6 +13,10 @@ public class PowerUpUtils {
     public static final int MAXIMUM_FLIPS_ALLOWED = 5;
     public static final int RED_BANNER = 1;
     public static final int GREEN_BANNER = 0;
+    public static final int DIALOG_PADDING_5 = 5;
+    public static final int DIALOG_PADDING_0 = 0;
+    public static final int DIALOG_LARGE_TEXT = 20;
+    public static final int DIALOG_SMALL_TEXT = 15;
 
     public static final String SCORE = "score";
     public static final String CORRECT_ANSWERS = "correct";

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,7 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="not_enough_points_dialog_message">You don\'t have enough points to buy that!</string>
+    <string name="not_enough_points_title_message">Oops!</string>
+    <string name="not_enough_points_dismiss_message">DISMISS</string>
 </resources>


### PR DESCRIPTION
### Description
Added a not enough points dialog for non-purchasable items in StoreActivity, so that if a user clicks a non-purchasable item, a dialog pops up. Below are screenshots of the fix from different screen sizes.
3.4 WQVGA API 25 (240x432 ldpi)
![screenshot_1515317425](https://user-images.githubusercontent.com/23027638/34648431-e71fd658-f3d3-11e7-9d90-cb2afc1df955.png)

Galaxy Nexus API 25 (720x1280 xhdpi)
![screenshot_1515317236](https://user-images.githubusercontent.com/23027638/34648432-ec11b2a8-f3d3-11e7-99a8-da15b27aa10f.png)

“New Device” API 25 (600 x 1024 hdpi)
![screenshot_1515317636](https://user-images.githubusercontent.com/23027638/34648435-f2f40dd2-f3d3-11e7-9b6c-486ed57c93ba.png)

Nexus S API 25 (480 x 800 hdpi)
![screenshot_1515317805](https://user-images.githubusercontent.com/23027638/34648439-06bba078-f3d4-11e7-9ae0-b634eab73732.png)

A task in Google Code-In 2018

### Type of Change:
- Code
- User Interface

### How Has This Been Tested?
This has been tested on my phone, and through multiple sizes on emulators to make sure that the sizes work.


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings 
