### PR TITLE
Program: GCI Adding Dialog in StoreActivity

### DIFF
--- a/PowerUp/app/src/main/res/values/integers.xml
+++ b/PowerUp/app/src/main/res/values/integers.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <integer name="store_dialog_title_textSize">20</integer>
+    <integer name="store_dialog_title_padding">20</integer>
+    <integer name="store_dialog_button_textSize">18</integer>
     <integer name="max_progress">100</integer>
     <integer name="half_progress">50</integer>
     <integer name="text_view_ems">10</integer>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,7 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="store_dialog_message">You don\'t have enough\n points to buy that!</string>
+    <string name="store_dialog_title">Oops!</string>
+    <string name="store_dialog_confirm_message">OK</string>
 </resources>


### PR DESCRIPTION
### Description
Pull Request as part of the GCI'17 task 'PowerUp Android: Create a not enough points dialog box for non-purchasable items'
### Major Changes
- The dialog has now been optimized to adjust height and width according to screen size aptly and precisely.
- The implementation works according to the intended functioning of the Activity. When and if an item is bought, it is marked as unlocked and the user can switch between different items he has bought. The Dialog shows only when an item is not bought and the user doesn't have enough points to unlock it.

### Screenshots
#### Nexus One (800x480)
![nexus one 800x480](https://user-images.githubusercontent.com/19228432/34667481-338955a8-f48f-11e7-827b-a1a8fed80e35.png)
#### Redmi 4 (1280x720)
![redmi 4 1280x720](https://user-images.githubusercontent.com/19228432/34667482-33d1941c-f48f-11e7-9bc8-a3f27cbbb7e9.png)
#### Pixel (1920x1080)
![pixel 1920x1080](https://user-images.githubusercontent.com/19228432/34667483-34123fe4-f48f-11e7-93f7-87ba25d00b80.png)
#### Pixel XL (2560x1440)
![Pixel XL (2560x1440)](https://user-images.githubusercontent.com/19228432/34667484-3450aee6-f48f-11e7-88d2-d319cb52ce79.png)


  
  