### PR TITLE
Improve code coverage: add missing unit tests to minigame activities

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
@@ -11,6 +11,8 @@ import powerup.systers.com.R;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class SinkToSwimEndActivity extends AppCompatActivity {
+    
+    public TextView scoreView, correctView, wrongView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -20,9 +22,9 @@ public class SinkToSwimEndActivity extends AppCompatActivity {
         int wrongAnswers= intent.getExtras().getInt(PowerUpUtils.WRONG_ANSWER);
         int correctAnswers= intent.getExtras().getInt(PowerUpUtils.CORRECT_ANSWERS);
         int score = intent.getExtras().getInt(PowerUpUtils.SCORE);
-        TextView  scoreView = (TextView) findViewById(R.id.swim_score);
-        TextView  correctView = (TextView) findViewById(R.id.correct);
-        TextView  wrongView = (TextView) findViewById(R.id.wrong);
+        scoreView = (TextView) findViewById(R.id.swim_score);
+        correctView = (TextView) findViewById(R.id.correct);
+        wrongView = (TextView) findViewById(R.id.wrong);
         scoreView.setText(""+score);
         correctView.setText(""+correctAnswers);
         wrongView.setText(""+wrongAnswers);

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/MinesweeperTutorialsTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/MinesweeperTutorialsTests.java
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertTrue;
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
 public class MinesweeperTutorialsTests {
 
-    MinesweeperTutorials activity;
-    ImageView tutorialView;
+    private MinesweeperTutorials activity;
+    private ImageView tutorialView;
 
     @Before
     public void setUp() throws Exception {

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/MinesweeperTutorialsTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/MinesweeperTutorialsTests.java
@@ -1,0 +1,70 @@
+package powerup.systers.com.powerup.test;
+
+import android.content.Intent;
+import android.os.Build;
+import android.widget.ImageView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowDrawable;
+
+import powerup.systers.com.BuildConfig;
+import powerup.systers.com.R;
+import powerup.systers.com.minesweeper.MinesweeperGameActivity;
+import powerup.systers.com.minesweeper.MinesweeperTutorials;
+import powerup.systers.com.powerup.PowerUpUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
+public class MinesweeperTutorialsTests {
+
+    MinesweeperTutorials activity;
+    ImageView tutorialView;
+
+    @Before
+    public void setUp() throws Exception {
+        activity = Robolectric.setupActivity(MinesweeperTutorials.class);
+        tutorialView = (ImageView) activity.findViewById(R.id.tut);
+    }
+
+    @Test
+    public void shouldNotBeNull() throws Exception {
+        assertNotNull(activity);
+    }
+
+    @Test
+    public void displaysCorrectTutorial() throws Exception {
+        ShadowDrawable shadowDrawable = Shadows.shadowOf(tutorialView.getDrawable());
+        for (int i = 0; i < PowerUpUtils.MINES_TUTS.length; i++) {
+            assertEquals(PowerUpUtils.MINES_TUTS[i], shadowDrawable.getCreatedFromResId());
+            tutorialView.performClick();
+            shadowDrawable = Shadows.shadowOf(tutorialView.getDrawable());
+        }
+    }
+
+    @Test
+    public void launchesNextActivityCorrectly() throws Exception {
+        // Go to the last tutorial screen before the activity changes
+        for (int i = 0; i < PowerUpUtils.MINES_TUTS.length; i++) {
+            tutorialView.performClick();
+        }
+
+        Class Minesweeper = MinesweeperGameActivity.class;
+        Intent expectedIntent = new Intent(activity, Minesweeper);
+        // Perform the last click that will launch the next activity
+        tutorialView.performClick();
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        Intent actualIntent = shadowActivity.getNextStartedActivity();
+        assertTrue(expectedIntent.filterEquals(actualIntent));
+    }
+}

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimEndTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimEndTests.java
@@ -30,21 +30,20 @@ import static org.junit.Assert.assertTrue;
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
 public class SinkToSwimEndTests {
 
-    private ActivityController<SinkToSwimEndActivity> controller;
     private SinkToSwimEndActivity activity;
 
     @Before
     public void setUp() {
-        controller = Robolectric.buildActivity(SinkToSwimEndActivity.class);
+        Robolectric.buildActivity(SinkToSwimEndActivity.class);
     }
 
     private void createWithIntent(int extra, String type) {
         Intent intent = new Intent(RuntimeEnvironment.application, SinkToSwimEndActivity.class);
-        if (type.equals("score")) {
+        if ("score".equals(type)) {
             intent.putExtra(PowerUpUtils.SCORE, extra);
-        } else if (type.equals("correct")) {
+        } else if ("correct".equals(type)) {
             intent.putExtra(PowerUpUtils.CORRECT_ANSWERS, extra);
-        } else if (type.equals("wrong")) {
+        } else if ("wrong".equals(type)) {
             intent.putExtra(PowerUpUtils.WRONG_ANSWER, extra);
         }
         activity = Robolectric.buildActivity(SinkToSwimEndActivity.class, intent)

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimEndTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimEndTests.java
@@ -1,0 +1,111 @@
+package powerup.systers.com.powerup.test;
+
+
+import android.content.Intent;
+import android.os.Build;
+import android.widget.ImageView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+
+import powerup.systers.com.BuildConfig;
+import powerup.systers.com.GameOverActivity;
+import powerup.systers.com.R;
+import powerup.systers.com.powerup.PowerUpUtils;
+import powerup.systers.com.sink_to_swim_game.SinkToSwimEndActivity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
+public class SinkToSwimEndTests {
+
+    private ActivityController<SinkToSwimEndActivity> controller;
+    private SinkToSwimEndActivity activity;
+
+    @Before
+    public void setUp() {
+        controller = Robolectric.buildActivity(SinkToSwimEndActivity.class);
+    }
+
+    private void createWithIntent(int extra, String type) {
+        Intent intent = new Intent(RuntimeEnvironment.application, SinkToSwimEndActivity.class);
+        if (type.equals("score")) {
+            intent.putExtra(PowerUpUtils.SCORE, extra);
+        } else if (type.equals("correct")) {
+            intent.putExtra(PowerUpUtils.CORRECT_ANSWERS, extra);
+        } else if (type.equals("wrong")) {
+            intent.putExtra(PowerUpUtils.WRONG_ANSWER, extra);
+        }
+        activity = Robolectric.buildActivity(SinkToSwimEndActivity.class, intent)
+                .create()
+                .start()
+                .resume()
+                .visible()
+                .get();
+    }
+
+    @Test
+    public void createsAndDestroysActivity() {
+        createWithIntent(12, "score");
+    }
+
+    @Test
+    public void shouldNotBeNull() throws Exception {
+        createWithIntent(12, "score");
+
+        assertNotNull(activity);
+    }
+
+    @Test
+    public void scoreDisplayedCorrectly(){
+        int expectedScore = 3;
+        createWithIntent(expectedScore, "score");
+
+        String actualScore = activity.scoreView.getText().toString();
+        assertEquals(""+expectedScore,actualScore);
+    }
+
+    @Test
+    public void correctAnswerDisplayedCorrectly(){
+        int expectedCorrect = 3;
+        createWithIntent(expectedCorrect, "correct");
+
+        String actualCorrect = activity.correctView.getText().toString();
+        assertEquals(""+expectedCorrect, actualCorrect);
+    }
+
+    @Test
+    public void wrongAnswerDisplayedCorrectly(){
+        int expectedWrong = 2;
+        createWithIntent(expectedWrong, "wrong");
+
+        String actualWrong = activity.wrongView.getText().toString();
+        assertEquals(""+expectedWrong,actualWrong);
+    }
+
+
+    @Test
+    public void launchesNextActivityCorrectly(){
+        createWithIntent(5, "score");
+        Class GameOver = GameOverActivity.class;
+        Intent expectedIntent = new Intent(activity, GameOver);
+
+        ImageView continueButton = (ImageView) activity.findViewById(R.id.continue_button);
+        continueButton.callOnClick();
+
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        Intent actualIntent = shadowActivity.getNextStartedActivity();
+        assertTrue(expectedIntent.filterEquals(actualIntent));
+    }
+}

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimTutorialsTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimTutorialsTests.java
@@ -23,13 +23,14 @@ import powerup.systers.com.sink_to_swim_game.SinkToSwimTutorials;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
 public class SinkToSwimTutorialsTests {
 
-    SinkToSwimTutorials activity;
-    ImageView tutorialView, startButton;
+    private SinkToSwimTutorials activity;
+    private ImageView tutorialView, startButton;
 
     @Before
     public void setUp() throws Exception {
@@ -77,11 +78,11 @@ public class SinkToSwimTutorialsTests {
 
     @Test
     public void startButtonNotClickableOnGameStart() throws Exception {
-        assertTrue(!startButton.isEnabled());
+        assertFalse(startButton.isEnabled());
     }
 
     @Test
     public void startButtonHiddenOnStart() throws Exception {
-        assertTrue(!startButton.isOpaque());
+        assertFalse(startButton.isOpaque());
     }
 }

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimTutorialsTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimTutorialsTests.java
@@ -1,0 +1,87 @@
+package powerup.systers.com.powerup.test;
+
+import android.content.Intent;
+import android.os.Build;
+import android.widget.ImageView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowDrawable;
+
+import powerup.systers.com.BuildConfig;
+import powerup.systers.com.R;
+import powerup.systers.com.powerup.PowerUpUtils;
+import powerup.systers.com.sink_to_swim_game.SinkToSwimGame;
+import powerup.systers.com.sink_to_swim_game.SinkToSwimTutorials;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
+public class SinkToSwimTutorialsTests {
+
+    SinkToSwimTutorials activity;
+    ImageView tutorialView, startButton;
+
+    @Before
+    public void setUp() throws Exception {
+        activity = Robolectric.setupActivity(SinkToSwimTutorials.class);
+        tutorialView = (ImageView) activity.findViewById(R.id.tut);
+        startButton = (ImageView) activity.findViewById(R.id.start_button);
+    }
+
+    @Test
+    public void shouldNotBeNull() throws Exception {
+        assertNotNull(activity);
+    }
+
+    @Test
+    public void displaysCorrectTutorial() throws Exception {
+        ShadowDrawable shadowDrawable = Shadows.shadowOf(tutorialView.getDrawable());
+        for (int i = 0; i < PowerUpUtils.SWIM_TUTS.length; i++) {
+            // If it is the last tutorial screen, check that the start button is enabled
+            if (i == PowerUpUtils.SWIM_TUTS.length - 1) {
+                assertTrue(startButton.isClickable());
+            }
+            assertEquals(PowerUpUtils.SWIM_TUTS[i], shadowDrawable.getCreatedFromResId());
+            tutorialView.performClick();
+            shadowDrawable = Shadows.shadowOf(tutorialView.getDrawable());
+        }
+    }
+
+    @Test
+    public void launchesNextActivityCorrectly() throws Exception {
+        // Go to the last tutorial screen before the activity changes
+        for (int i = 0; i < PowerUpUtils.SWIM_TUTS.length; i++) {
+            tutorialView.performClick();
+        }
+
+        ImageView startButton = (ImageView) activity.findViewById(R.id.start_button);
+
+        Class SinkToSwim = SinkToSwimGame.class;
+        Intent expectedIntent = new Intent(activity, SinkToSwim);
+        startButton.performClick();
+
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        Intent actualIntent = shadowActivity.getNextStartedActivity();
+        assertTrue(expectedIntent.filterEquals(actualIntent));
+    }
+
+    @Test
+    public void startButtonNotClickableOnGameStart() throws Exception {
+        assertTrue(!startButton.isEnabled());
+    }
+
+    @Test
+    public void startButtonHiddenOnStart() throws Exception {
+        assertTrue(!startButton.isOpaque());
+    }
+}

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/VocabMatchTutorialsTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/VocabMatchTutorialsTests.java
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertTrue;
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
 public class VocabMatchTutorialsTests {
 
-    VocabMatchTutorials activity;
-    ImageView tutorialView;
+    private VocabMatchTutorials activity;
+    private ImageView tutorialView;
 
     @Before
     public void setUp() throws Exception {

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/VocabMatchTutorialsTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/VocabMatchTutorialsTests.java
@@ -1,0 +1,70 @@
+package powerup.systers.com.powerup.test;
+
+import android.content.Intent;
+import android.os.Build;
+import android.widget.ImageView;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowDrawable;
+
+import powerup.systers.com.BuildConfig;
+import powerup.systers.com.R;
+import powerup.systers.com.powerup.PowerUpUtils;
+import powerup.systers.com.vocab_match_game.VocabMatchGameActivity;
+import powerup.systers.com.vocab_match_game.VocabMatchTutorials;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
+public class VocabMatchTutorialsTests {
+
+    VocabMatchTutorials activity;
+    ImageView tutorialView;
+
+    @Before
+    public void setUp() throws Exception {
+        activity = Robolectric.setupActivity(VocabMatchTutorials.class);
+        tutorialView = (ImageView) activity.findViewById(R.id.tut);
+    }
+
+    @Test
+    public void shouldNotBeNull() throws Exception {
+        assertNotNull(activity);
+    }
+
+    @Test
+    public void displaysCorrectTutorial() throws Exception {
+        ShadowDrawable shadowDrawable = Shadows.shadowOf(tutorialView.getDrawable());
+        for (int i = 0; i < PowerUpUtils.VOCAB_MATCH_TUTS.length; i++) {
+            assertEquals(PowerUpUtils.VOCAB_MATCH_TUTS[i], shadowDrawable.getCreatedFromResId());
+            tutorialView.performClick();
+            shadowDrawable = Shadows.shadowOf(tutorialView.getDrawable());
+        }
+    }
+
+    @Test
+    public void launchesNextActivityCorrectly() throws Exception {
+        // Go to the last tutorial screen before the activity changes
+        for (int i = 0; i < PowerUpUtils.VOCAB_MATCH_TUTS.length; i++) {
+            tutorialView.performClick();
+        }
+
+        Class VocabMatch = VocabMatchGameActivity.class;
+        Intent expectedIntent = new Intent(activity, VocabMatch);
+        // Perform the last click that will launch the next activity
+        tutorialView.performClick();
+        ShadowActivity shadowActivity = Shadows.shadowOf(activity);
+        Intent actualIntent = shadowActivity.getNextStartedActivity();
+        assertTrue(expectedIntent.filterEquals(actualIntent));
+    }
+}


### PR DESCRIPTION
### Description
Some of the minigame activities do not have unit tests, so they have 0% code coverage. I have created tests for SinkToSwimEndActivity.java, SinkToSwimTutorials.java, VocabMatchTutorials.java, and MinesweeperTutorials.java to improve code coverage for the rest of the minigame activities.

### Type of Change:

- Code
- Quality Assurance

### How Has This Been Tested?
Before the tests were implemented, this was the code coverage for PowerUp:
![Code coverage before](https://c1.staticflickr.com/5/4638/39470115442_0f37262cff_b.jpg)

After adding the tests, this is the current coverage:
![Code coverage after](https://c1.staticflickr.com/5/4620/38697035195_ee1322c0b8_b.jpg)

Code coverage for the recently implemented tests are now 100%.

Sink To Swim code coverage and successful tests (end activity and tutorials have 100%)
![Swim coverage](https://c1.staticflickr.com/5/4751/38697035375_3fa37fc3d8_b.jpg)
![SinkToSwimEndTests](https://c1.staticflickr.com/5/4616/39592817041_55a15fa6cc_b.jpg)
![SinkToSwimTutorials](https://c1.staticflickr.com/5/4614/38697035505_bf9c2bf2bd_b.jpg)

Vocab Match code coverage and successful tests (tutorials have 100%)
![Vocab coverage](https://c1.staticflickr.com/5/4716/38697035445_7b9237dd18_b.jpg)
![VocabMatchTutorials](https://c1.staticflickr.com/5/4632/38697035825_a91232cc02_b.jpg)
### Checklist:

Minesweeper code coverage and successful tests (tutorials have 100%)
![Minesweeper coverage](https://c1.staticflickr.com/5/4675/38697035275_accf42a9b7_b.jpg)
![MinesweeperTutorials](https://c1.staticflickr.com/5/4656/38697036425_5955f5290a_b.jpg)

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials
- [X] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
