### PR TITLE
Program GCI: Include Scenario Name on Scenario Over activity

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -59,6 +59,9 @@ public class ScenarioOverActivity extends AppCompatActivity {
         TextView karmaPoints = (TextView) findViewById(R.id.karmaPoints);
         
         karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+
+        TextView currentScenario = (TextView) findViewById(R.id.currentScenario);
+        currentScenario.setText(currentScenario.getText() + " " + scene.getScenarioName());
         continueButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
@@ -9,6 +9,17 @@
     tools:context="powerup.systers.com.ScenarioOverActivity"
     android:id="@+id/root">
 
+    <TextView
+        android:id="@+id/currentScenario"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/current_scenario_height"
+        android:layout_marginTop="@dimen/current_scenario_marginTop"
+        android:gravity="center"
+        android:text="@string/scenario_over_current_text"
+        android:textSize="@dimen/current_scenario_textSize"
+        android:textColor="@color/current_scenario_text"
+        android:textStyle="bold"/>
+
     <ImageView
         android:id="@+id/replayButton"
         android:layout_width="@dimen/continue_width"

--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -238,4 +238,7 @@
     <dimen name="replay_marginTop">400dp</dimen>
     <dimen name="replay_marginLeft">180dp</dimen>
     <dimen name="hair_button_marginLeft">100dp</dimen>
+    <dimen name="current_scenario_height">60dp</dimen>
+    <dimen name="current_scenario_textSize">20sp</dimen>
+    <dimen name="current_scenario_marginTop">50dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values-large/dimens.xml
+++ b/PowerUp/app/src/main/res/values-large/dimens.xml
@@ -73,4 +73,7 @@
     <dimen name="replay_marginTop">270dp</dimen>
     <dimen name="replay_marginLeft">180dp</dimen>
     <dimen name="hair_button_marginLeft">150dp</dimen>
+    <dimen name="current_scenario_height">90dp</dimen>
+    <dimen name="current_scenario_textSize">30sp</dimen>
+    <dimen name="current_scenario_marginTop">78dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values-normal/dimens.xml
+++ b/PowerUp/app/src/main/res/values-normal/dimens.xml
@@ -60,4 +60,7 @@
     <dimen name="replay_marginTop">180dp</dimen>
     <dimen name="replay_marginLeft">110dp</dimen>
     <dimen name="hair_button_marginLeft">100dp</dimen>
+    <dimen name="current_scenario_height">60dp</dimen>
+    <dimen name="current_scenario_textSize">25sp</dimen>
+    <dimen name="current_scenario_marginTop">50dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values-small/dimens.xml
+++ b/PowerUp/app/src/main/res/values-small/dimens.xml
@@ -39,4 +39,7 @@
     <dimen name="selection_text_size">14sp</dimen>
     <dimen name="start_height">20dp</dimen>
     <dimen name="hair_button_marginLeft">75dp</dimen>
+    <dimen name="current_scenario_height">45dp</dimen>
+    <dimen name="current_scenario_textSize">20sp</dimen>
+    <dimen name="current_scenario_marginTop">41dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values-xlarge/dimens.xml
+++ b/PowerUp/app/src/main/res/values-xlarge/dimens.xml
@@ -71,4 +71,7 @@
     <dimen name="replay_marginTop">400dp</dimen>
     <dimen name="replay_marginLeft">180dp</dimen>
     <dimen name="hair_button_marginLeft">200dp</dimen>
+    <dimen name="current_scenario_height">120dp</dimen>
+    <dimen name="current_scenario_textSize">45sp</dimen>
+    <dimen name="current_scenario_marginTop">103dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values/color.xml
+++ b/PowerUp/app/src/main/res/values/color.xml
@@ -11,4 +11,5 @@
     <color name="correct_answer">#69FF6E</color>
     <color name="wrong_answer">#FF6969</color>
     <color name="score_text">#6EBFE1</color>
+    <color name="current_scenario_text">#457892</color>
 </resources>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="scenario_over_current_text">Current Scenario: </string>
 </resources>


### PR DESCRIPTION
### Description
To make the android app match the iOS app, I added the current scenario name on the Scenario Over Activity. I made sure the color of the text and other styles(font, size, margins) was the same in the iOS. Below are screenshots of the fix from different screen sizes.

Nexus S API 25 (480 x 800 hdpi)
<img width="486" alt="screen shot 2018-01-11 at 8 14 48 am" src="https://user-images.githubusercontent.com/23027638/34803113-71c1354c-f6ac-11e7-9605-e62a63002914.png">

3.4 WQVGA API 25 (240x432 ldpi)
<img width="433" alt="screen shot 2018-01-11 at 8 48 32 am" src="https://user-images.githubusercontent.com/23027638/34803132-943cb7c2-f6ac-11e7-90f8-e198bb90aea6.png">

Galaxy Nexus API 25 (720x1280 xhdpi)
<img width="485" alt="screen shot 2018-01-11 at 8 49 10 am" src="https://user-images.githubusercontent.com/23027638/34803140-9d5d2aee-f6ac-11e7-82b0-21c882149209.png">

“New Device” API 25 (600 x 1024 hdpi)
<img width="643" alt="screen shot 2018-01-11 at 6 35 01 pm" src="https://user-images.githubusercontent.com/23027638/34821605-49bfdc12-f6ff-11e7-9194-23aa20984658.png">

Fixes #853 

### Type of Change:
- Code
- User Interface

### How Has This Been Tested?
I tested this by using the app on different phone sizes using the emulator to make sure that the sizes were accurate.

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
