### PR TITLE
Program: GCI Include scenario name on scenario over activity

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -229,7 +229,6 @@ public class GameActivity extends Activity {
         // If completed check if it is last scene
         if (prevScene != null && prevScene.getCompleted() == 1) {
                 SessionHistory.prevSessionID = scene.getId();
-                SessionHistory.currSessionID = scene.getNextScenarioID();
                 if (type == 0) {
                     Intent intent = new Intent(GameActivity.this, ScenarioOverActivity.class);
                     intent.putExtra(String.valueOf(R.string.scene), prevScene.getScenarioName());

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -55,6 +55,9 @@ public class ScenarioOverActivity extends AppCompatActivity {
                 startActivity(new Intent(ScenarioOverActivity.this, MapActivity.class));
             }
         });
+        TextView scenarioCompleted = (TextView) findViewById(R.id.completedScenario);
+        scenarioCompleted.setText(scenarioCompleted.getText() + " " + scene.getScenarioName());
+        SessionHistory.currSessionID = scene.getNextScenarioID();
 
         TextView karmaPoints = (TextView) findViewById(R.id.karmaPoints);
         

--- a/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
@@ -53,4 +53,15 @@
         android:textSize="@dimen/karma_points_textSize"
         android:textColor="@color/powerup_black"/>
 
+    <TextView
+        android:id="@+id/completedScenario"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/karmaPoints"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="@dimen/current_scenario_top_margin"
+        android:textStyle="bold"
+        android:textColor="@color/score_color"
+        android:textSize="@dimen/current_scenario_text_size"
+        android:text="@string/current_scenario_text"/>
 </RelativeLayout>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <resources>
     <dimen name="banner_height">30dp</dimen>
+    <dimen name="current_scenario_text_size">20sp</dimen>
+    <dimen name="current_scenario_top_margin">23dp</dimen>
 </resources>
 

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="current_scenario_text">Current Scenario:</string>
 </resources>


### PR DESCRIPTION
### Description
I included scenario name on scenario over activity.
When I executed the code, the problem I faced is that the text shows the name of next scenario like, If I complete a home scenario then at the scenario over screen shows "Completed scenario: School" which is next to the home scenario. 
To solve this, I have removed get next scenario ID in game activity and put it after the text load in scenarioOverActivity.

Fixes https://github.com/systers/powerup-android/issues/853

## Screenshots

1440x2560
![1440x2560](https://user-images.githubusercontent.com/30840527/34813500-3aa16b1c-f6d0-11e7-96a5-984cf42f6143.png)

1280x768
![768x1280](https://user-images.githubusercontent.com/30840527/34813523-4f77c4aa-f6d0-11e7-90cc-db4327b1817d.png)

1024x600
![1024x600](https://user-images.githubusercontent.com/30840527/34813506-42b07cd0-f6d0-11e7-8de1-661fc6978f15.png)

240x432
![240x 432](https://user-images.githubusercontent.com/30840527/34813563-6caead22-f6d0-11e7-9825-d6362d92b549.png)

