### PR TITLE
Program GCI: Include scenario name on scenario over activity

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -34,6 +34,7 @@ public class MapActivity extends Activity {
             } else {
                 Intent intent = new Intent(MapActivity.this, ScenarioOverActivity.class);
                 intent.putExtra(PowerUpUtils.SOURCE,PowerUpUtils.MAP);
+                intent.putExtra(PowerUpUtils.SCENARIO_NAME, getScenarioName(scenarioChooser.getId()));
                 startActivityForResult(intent, 0);
             }
             finish();

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -48,6 +48,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
         ImageView replayButton = (ImageView) findViewById(R.id.replayButton);
         ImageView continueButton = (ImageView) findViewById(R.id.continueButton);
         Button mapButton = (Button) findViewById(R.id.mapButton);
+        TextView scenarioNameText = (TextView) findViewById(R.id.scenario_name);
         mapButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -71,7 +72,6 @@ public class ScenarioOverActivity extends AppCompatActivity {
             continueButton.setOnClickListener(null);
         }
 
-
         replayButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -87,6 +87,15 @@ public class ScenarioOverActivity extends AppCompatActivity {
                 startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
             }
         });
+        String scenarioName;
+        if (getIntent().getExtras().containsKey(PowerUpUtils.SCENARIO_NAME)) {
+            // we are redirected from map or mini game
+            scenarioName = getIntent().getStringExtra(PowerUpUtils.SCENARIO_NAME);
+        } else {
+            // we are redirected from game
+            scenarioName = getmDbHandler().getScenarioFromID(SessionHistory.prevSessionID).getScenarioName();
+        }
+        scenarioNameText.setText(getString(R.string.scenario_name_format, scenarioName));
     }
 
     /**

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
@@ -46,6 +46,7 @@ public class ProsAndConsActivity extends AppCompatActivity {
             new MinesweeperSessionManager(this).saveMinesweeperOpenedStatus(false); //marks minesweeper game as finished
             Intent intent = new Intent(ProsAndConsActivity.this, ScenarioOverActivity.class);
             intent.putExtra(String.valueOf(R.string.scene), PowerUpUtils.MINESWEEP_PREVIOUS_SCENARIO);
+            intent.putExtra(PowerUpUtils.SCENARIO_NAME, getString(R.string.house));
             startActivity(intent);
         }
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -19,6 +19,7 @@ public class PowerUpUtils {
     public static final String WRONG_ANSWER = "wrong";
     public static final String MAP = "map";
     public static final String SOURCE = "source";
+    public static final String SCENARIO_NAME = "selected_scenario";
 
 
     public static final String CALLED_BY = "TUTORIALS_ACTIVITY";

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
@@ -30,6 +30,7 @@ public class SinkToSwimEndActivity extends AppCompatActivity {
 
     public void continuePressed(View view){
         Intent intent = new Intent(SinkToSwimEndActivity.this, GameOverActivity.class);
+        intent.putExtra(PowerUpUtils.SCENARIO_NAME, getString(R.string.school));
         finish();
         startActivityForResult(intent, 0);
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
@@ -33,6 +33,7 @@ public class VocabMatchEndActivity extends AppCompatActivity {
 
     public void continuePressed(View view){
         Intent intent = new Intent(VocabMatchEndActivity.this, ScenarioOverActivity.class);
+        intent.putExtra(PowerUpUtils.SCENARIO_NAME, getString(R.string.hospital));
         finish();
         startActivity(intent);
     }

--- a/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
@@ -53,4 +53,16 @@
         android:textSize="@dimen/karma_points_textSize"
         android:textColor="@color/powerup_black"/>
 
+    <TextView xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/scenario_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/karmaPoints"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="@dimen/scenario_name_margin"
+        android:textAppearance="@style/TextAppearance.AppCompat.Title"
+        android:textColor="@color/score_color"
+        android:textStyle="bold"
+        tools:text="Current Scenario: Home" />
+
 </RelativeLayout>

--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -238,4 +238,5 @@
     <dimen name="replay_marginTop">400dp</dimen>
     <dimen name="replay_marginLeft">180dp</dimen>
     <dimen name="hair_button_marginLeft">100dp</dimen>
+    <dimen name="scenario_name_margin">16dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="scenario_name_format">Current scenario: %s</string>
 </resources>


### PR DESCRIPTION
Scenario name displays when redirecting from all of the existing variants: scenario, minigame, and map.

Fixes #853 

## Screenshots
3,7' 800x480:
![sn_3 7_480_800](https://user-images.githubusercontent.com/18180597/34815388-5490e60a-f6db-11e7-9123-c13033b25688.png)
4,7' 1280x720:
![sn_4 7_1280_720](https://user-images.githubusercontent.com/18180597/34815399-5ea2d478-f6db-11e7-9aa5-33245552b18a.png)
5' 1920x1080:
![sn_5_1920_1080](https://user-images.githubusercontent.com/18180597/34815404-6a5c8066-f6db-11e7-96ab-c20832035bf8.png)
5,7' 1440x2560:
![sn_5 7_1440_2560](https://user-images.githubusercontent.com/18180597/34815426-7a415f6a-f6db-11e7-8fb9-bcc96c3259ac.png)
