### PR TITLE
Increase time for color change animation in Vocab Match Game.

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -13,6 +13,7 @@ public class PowerUpUtils {
     public static final int MAXIMUM_FLIPS_ALLOWED = 5;
     public static final int RED_BANNER = 1;
     public static final int GREEN_BANNER = 0;
+    public static final int BOARD_ANIMATION_DELAY_TIME = 400;
 
     public static final String SCORE = "score";
     public static final String CORRECT_ANSWERS = "correct";

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -128,7 +128,7 @@ public class VocabMatchGameActivity extends AppCompatActivity {
                     public void run() {
                         boardView.setBackground(getResources().getDrawable(R.drawable.vocab_clipboard_yellow));
                     }
-                },2);
+                }, PowerUpUtils.BOARD_ANIMATION_DELAY_TIME);
                 latestTile++;
 
 


### PR DESCRIPTION
### Description
The time for the color change animation is increased from 2 milliseconds to 400 milliseconds which makes the animation noticeable and does not give an impression of lag or game pause.

Fixes #900 

### Type of Change:

- Code
- Quality Assurance
- User Interface
- Bug fix (non-breaking change which fixes an issue)



### Checklist:
- [x] My PR follows the style guidelines for this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes

## Screenshots:
![image](https://user-images.githubusercontent.com/28915865/34819210-2660941c-f6e3-11e7-9ebc-02567f6adf29.png)
![image](https://user-images.githubusercontent.com/28915865/34819228-2dead15c-f6e3-11e7-9217-82fa8a031753.png)
