### PR TITLE
Add dialogs for confirming item purchase

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -1,5 +1,10 @@
 package powerup.systers.com.powerup;
 
+
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.support.v7.app.AlertDialog;
+
 import powerup.systers.com.R;
 
 /**
@@ -49,11 +54,24 @@ public class PowerUpUtils {
 
     public static final int[] HAIR_IMAGES = {R.drawable.hair1,R.drawable.hair2,R.drawable.hair3,R.drawable.hair4,R.drawable.hair5,R.drawable.hair6,R.drawable.hair7,R.drawable.hair8,R.drawable.hair9,R.drawable.hair10,R.drawable.hair11,R.drawable.hair12,R.drawable.hair13,R.drawable.hair14,R.drawable.hair15,R.drawable.hair16};
     public static final String[] HAIR_POINTS_TEXTS = {"5","5","5","10","10","10","5","5","10","5","5","10","10","10","5","5"};
+    public static final int HAIR_TYPE = 0;
 
     public static final int[] CLOTHES_IMAGES = {R.drawable.dress1,R.drawable.dress2,R.drawable.dress3,R.drawable.dress4};
     public static final String[] CLOTHES_POINTS_TEXTS = {"5","10","10","10"};
+    public static final int CLOTHES_TYPE = 1;
 
     public static final int[] ACCESSORIES_IMAGES = {R.drawable.acc1,R.drawable.acc2,R.drawable.acc3,R.drawable.acc4};
     public static final String[] ACCESSORIES_POINTS_TEXTS = {"10","5","5","10"};
+    public static final int ACCESSORIES_TYPE = 2;
+
+    /**
+     * Applies the properties/theme to the Dialog. Should be used by all dialogs in PowerUp to ensure uniformity
+     * @param dialog Dialog to apply the properties to
+     */
+    public static void setPropertiesForDialog(AlertDialog dialog){
+        ColorDrawable drawable = new ColorDrawable(Color.WHITE);
+        drawable.setAlpha(200);
+        dialog.getWindow().setBackgroundDrawable(drawable);
+    }
 }
 

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,11 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="store_purchase_message">Are you sure you want to purchase these items? You will be spending $%1$s and the purchase can\'t be reverted</string>
+    <string name="store_purchase_title">Warning</string>
+    <string name="store_purchase_confirm_message">Purchase</string>
+    <string name="store_purchase_cancel_message">Maybe not</string>
+    <string name="store_purchase_successful_title">Yay!</string>
+    <string name="store_purchase_successful_message">The purchase is successful</string>
+    <string name="store_purchase_successful_close_button">OK</string>
 </resources>


### PR DESCRIPTION
### Description
Adds warning and purchase successful dialogs before and after item purchase from the store

Fixes #852

### Type of Change:
- Code
- User Interface
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Ran it on 2 devices and an emulator


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] My changes generate no new warnings 
