### PR TITLE
Program: GCI Include a Scenario Over Screen after Library scenario

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -63,7 +63,11 @@ public class ScenarioOverActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 new GameActivity().gameActivityInstance.finish();
-                startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+                if (getIntent().getBooleanExtra(PowerUpUtils.FINAL_SCENARIO, false)) {
+                    startActivity(new Intent(ScenarioOverActivity.this, GameOverActivity.class));
+                } else {
+                    startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+                }
             }
         });
         if (getIntent().getExtras()!=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE))){

--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -55,5 +55,6 @@ public class PowerUpUtils {
 
     public static final int[] ACCESSORIES_IMAGES = {R.drawable.acc1,R.drawable.acc2,R.drawable.acc3,R.drawable.acc4};
     public static final String[] ACCESSORIES_POINTS_TEXTS = {"10","5","5","10"};
+    public static final String FINAL_SCENARIO = "final scenario";
 }
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimEndActivity.java
@@ -8,6 +8,7 @@ import android.widget.TextView;
 
 import powerup.systers.com.GameOverActivity;
 import powerup.systers.com.R;
+import powerup.systers.com.ScenarioOverActivity;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class SinkToSwimEndActivity extends AppCompatActivity {
@@ -29,7 +30,8 @@ public class SinkToSwimEndActivity extends AppCompatActivity {
     }
 
     public void continuePressed(View view){
-        Intent intent = new Intent(SinkToSwimEndActivity.this, GameOverActivity.class);
+        Intent intent = new Intent(SinkToSwimEndActivity.this, ScenarioOverActivity.class);
+        intent.putExtra(PowerUpUtils.FINAL_SCENARIO, true);
         finish();
         startActivityForResult(intent, 0);
     }


### PR DESCRIPTION
### Description
Include a Scenario Over Screen after Library scenario. 
I have added some code which handles the ScenarioOverActivity and GameOverActivity. 

#### Functionality: 
When a user completes one scenario, they will redirected to GameActivity (next) and if the scenario is final, they will redirected to GameOverActivity but in Library scenario mini game i.e. sink to swim, they will redirected to ScenarioOverActivity (according to the code in SinkToSwimEndActivity) and then according to the code, Library scenario is final scenario so the ScenarioOverActivity redirects to GameOverActivity.

#### GIF
![img_0243](https://user-images.githubusercontent.com/30840527/34832105-f04f8442-f70e-11e7-91a4-e011aa311cbc.GIF)



