### PR TITLE
Purchased item selected warning dialog

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
@@ -2,8 +2,10 @@ package powerup.systers.com;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -306,6 +308,9 @@ public class StoreActivity extends AppCompatActivity {
                         TextView itemPoints = (TextView) v.findViewById(R.id.item_points);
                         int index = calculatePosition(position)+1;
                         if (storeItemTypeindex == 0) { //hair
+                            if (getmDbHandler().getAvatarHair() == index){
+                                alreadySelected();
+                            }
                             setAvatarHair(index);
                             if (getmDbHandler().getPurchasedHair(index) == 0){
                                 SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
@@ -315,6 +320,9 @@ public class StoreActivity extends AppCompatActivity {
                             }
 
                         } else if (storeItemTypeindex == 1) { //clothes
+                            if (getmDbHandler().getAvatarCloth() == index){
+                                alreadySelected();
+                            }
                             setAvatarClothes(index);
                             if (getmDbHandler().getPurchasedClothes(index) == 0){
                                 SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
@@ -323,6 +331,9 @@ public class StoreActivity extends AppCompatActivity {
                             }
 
                         } else if (storeItemTypeindex == 2) { //accessories
+                            if (getmDbHandler().getAvatarAccessory() == index){
+                                alreadySelected();
+                            }
                             setAvatarAccessories(index);
                             if (getmDbHandler().getPurchasedAccessories(index) == 0){
                                 SessionHistory.totalPoints -= Integer.parseInt(itemPoints.getText().toString());
@@ -359,6 +370,22 @@ public class StoreActivity extends AppCompatActivity {
             return storeItem;
         }
 
+    }
+
+    public void alreadySelected(){
+        android.support.v7.app.AlertDialog.Builder builder = new android.support.v7.app.AlertDialog.Builder(StoreActivity.this);
+        builder.setTitle(this.getResources().getString(R.string.already_selected_title_message))
+                .setMessage(getResources().getString(R.string.already_selected_dialog_message));
+        builder.setPositiveButton(R.string.already_selected_dismiss_message, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                dialog.dismiss();
+            }
+        });
+        android.support.v7.app.AlertDialog dialog = builder.create();
+        ColorDrawable drawable = new ColorDrawable(Color.WHITE);
+        drawable.setAlpha(200);
+        dialog.getWindow().setBackgroundDrawable(drawable);
+        dialog.show();
     }
 
     public int getPurchasedStatus(int index) {

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,7 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="already_selected_dialog_message">This item is already chosen</string>
+    <string name="already_selected_title_message">Already Selected</string>
+    <string name="already_selected_dismiss_message">OK</string>
 </resources>


### PR DESCRIPTION
### Description
Added an 'already selected' dialog for when a user clicks an item in the store activity that is already being worn. Below are some screenshots of the dialog in different phone sizes:

Galaxy Nexus API 25 (720x1280 xhdpi)
![screenshot_1515738874](https://user-images.githubusercontent.com/23027638/34862504-be63073c-f7a5-11e7-8136-25a6d48bce71.png)

Nexus S API 25 (480 x 800 hdpi)
![screenshot_1515738958](https://user-images.githubusercontent.com/23027638/34862536-ee1bcb8a-f7a5-11e7-8b55-37979b80cf6b.png)

3.4 WQVGA API 25 (240x432 ldpi)
![screenshot_1515739034](https://user-images.githubusercontent.com/23027638/34862573-18ee8ea6-f7a6-11e7-8ded-944263c856c4.png)

“New Device” API 25 (600 x 1024 hdpi)
![screenshot_1515739135](https://user-images.githubusercontent.com/23027638/34862611-54e522f8-f7a6-11e7-9bf4-8b611def10bf.png)

Fixes #886

### Type of Change:
- Code
- User Interface

### How Has This Been Tested?
I ran the app on different phones with different screen sizes on an emulator to make sure that the dialog still looks nice.

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials