### PR TITLE
Fix minesweeper reopening on new game

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -23,6 +23,8 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.Toast;
 
+import powerup.systers.com.minesweeper.MinesweeperSessionManager;
+
 public class StartActivity extends Activity {
 
     private SharedPreferences preferences;
@@ -48,6 +50,12 @@ public class StartActivity extends Activity {
                         .setMessage(getResources().getString(R.string.start_dialog_message));
                 builder.setPositiveButton(getString(R.string.start_confirm_message), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
+                        /*
+                         We make the minesweeper opened status to false so that the PowerUp game starts
+                         over from first instead of continuing the previous Minesweeper game as the
+                         user chooses to start over
+                        */
+                        new MinesweeperSessionManager(StartActivity.this).saveMinesweeperOpenedStatus(false);
                         startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
                     }
                 });


### PR DESCRIPTION
### Descriptio
Fixes the problem where minesweeper game opens on selection of New Game when a previous minesweeper game is left unfinished.

Fixes #891

### Type of Change:
- Code
- User Interface
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Ran this on a phone and an emulator


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] My changes generate no new warnings 
