### PR TITLE
Add slide in left to right animation on StoreActivity start.

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -91,6 +91,7 @@ public class MapActivity extends Activity {
             @Override
             public void onClick(View v) {
                 startActivity(new Intent(MapActivity.this, StoreActivity.class));
+                overridePendingTransition(android.R.anim.slide_in_left, android.R.anim.slide_out_right);
             }
         });
 


### PR DESCRIPTION
### Description
Add animation to StoreActivity start. When Store is clicked from Map, the store should slide in from the left to right.

### Type of Change:


- Code

- User Interface
- New feature (non-breaking change which adds functionality pre-approved by mentors)
### Checklist:

- [x] My PR follows the style guidelines for this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes

![20180112_143618](https://user-images.githubusercontent.com/28915865/34867673-07cffaaa-f7a7-11e7-990f-f4a9c9a6e20e.gif)
