### PR TITLE
Program: GCI Rectify the implementation of MineSweeper game

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -23,6 +23,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.Toast;
 
+import powerup.systers.com.minesweeper.MinesweeperSessionManager;
 public class StartActivity extends Activity {
 
     private SharedPreferences preferences;
@@ -48,6 +49,7 @@ public class StartActivity extends Activity {
                         .setMessage(getResources().getString(R.string.start_dialog_message));
                 builder.setPositiveButton(getString(R.string.start_confirm_message), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
+                        new MinesweeperSessionManager(StartActivity.this).saveMinesweeperOpenedStatus(false);
                         startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
                     }
                 });


### PR DESCRIPTION
### Description
The Minesweeper game will not show if user leave the game and then play a new game.

Fixes https://github.com/systers/powerup-android/issues/891

#### Functionality
When a user left the game while playing Minesweeper game and then play a new game, the minesweeper game will not show anymore. When a player clicks on Create New Avatar" then I set the minesweeper open status as false.