### PR TITLE
Program: GCI Add Ripple Effect to Game Dialogue

### DIFF
--- a/PowerUp/app/src/main/res/drawable-v21/ripple_gray.xml
+++ b/PowerUp/app/src/main/res/drawable-v21/ripple_gray.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@android:color/darker_gray">
+    <item android:drawable="@android:color/white"/>
+</ripple>

--- a/PowerUp/app/src/main/res/drawable/ripple_gray.xml
+++ b/PowerUp/app/src/main/res/drawable/ripple_gray.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+<item android:state_pressed="true">
+    <shape xmlns:android="http://schemas.android.com/apk/res/android" >
+        <corners android:radius="@dimen/ripple_radius"/>
+        <solid android:color="@android:color/darker_gray"/>
+    </shape>
+</item>
+<item>
+    <shape xmlns:android="http://schemas.android.com/apk/res/android" >
+        <corners android:radius="@dimen/ripple_radius"/>
+        <solid android:color="@android:color/white"/>
+    </shape>
+</item>
+</selector>

--- a/PowerUp/app/src/main/res/layout-land/game_activity.xml
+++ b/PowerUp/app/src/main/res/layout-land/game_activity.xml
@@ -90,12 +90,14 @@
         android:paddingBottom="@dimen/conversation_margin"
         android:paddingLeft="@dimen/game_padding_left"
         android:paddingRight="@dimen/conversation_margin"
+        android:paddingTop="@dimen/game_padding_top"
         android:id="@+id/mainListView"
         android:layout_width="@dimen/answer_listview_width"
         android:layout_height="@dimen/main_list_view_height"
         android:layout_toRightOf="@id/relativeLayout"
         android:layout_centerVertical="true"
         android:background="@drawable/left_conversation"
+        android:listSelector="@drawable/ripple_gray"
         android:clickable="true"/>
     <TextView
         android:textColor="@color/powerup_black"

--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -238,4 +238,6 @@
     <dimen name="replay_marginTop">400dp</dimen>
     <dimen name="replay_marginLeft">180dp</dimen>
     <dimen name="hair_button_marginLeft">100dp</dimen>
+    <dimen name="game_padding_top">20dp</dimen>
+    <dimen name="ripple_radius">3dp</dimen>
 </resources>


### PR DESCRIPTION
### Description
Pull Request as part of the GCI'17 task 'PowerUp Android: Add Ripple effect on selecting dialogue'

Fixes #903 
### Changes
- Along with the addition of the ripple effect a PaddingTop attribute has also been added to the ListView so as to prevent the overflow of content from the LeftConversation Background.
### Type of Change:

- User Interface

### How Has This Been Tested?
#### Debug Run. GIF Attached
![ripple](https://user-images.githubusercontent.com/19228432/34875817-dd0718ee-f7c4-11e7-8513-c4136822d571.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings 