### PR TITLE
Add name of scenario to ScenarioOverActivity.

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -232,7 +232,7 @@ public class GameActivity extends Activity {
                 SessionHistory.currSessionID = scene.getNextScenarioID();
                 if (type == 0) {
                     Intent intent = new Intent(GameActivity.this, ScenarioOverActivity.class);
-                    intent.putExtra(String.valueOf(R.string.scene), prevScene.getScenarioName());
+                    intent.putExtra(getString(R.string.scene), prevScene.getScenarioName());
                     startActivity(intent);
                 } else if (type == -1) {
                     new MinesweeperSessionManager(this).saveMinesweeperOpenedStatus(true); //marks minesweeper game as opened and incompleted

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -33,6 +33,7 @@ public class MapActivity extends Activity {
                 startActivity(new Intent(MapActivity.this, MinesweeperGameActivity.class));
             } else {
                 Intent intent = new Intent(MapActivity.this, ScenarioOverActivity.class);
+                intent.putExtra(getString(R.string.scene), getScenarioName(scenarioChooser.getId()));
                 intent.putExtra(PowerUpUtils.SOURCE,PowerUpUtils.MAP);
                 startActivityForResult(intent, 0);
             }

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -45,9 +45,15 @@ public class ScenarioOverActivity extends AppCompatActivity {
         setContentView(R.layout.activity_scenario_over);
         scene = getmDbHandler().getScenario();
         scenarioActivityDone = 1;
+        Bundle bundle = getIntent().getExtras();
         ImageView replayButton = (ImageView) findViewById(R.id.replayButton);
         ImageView continueButton = (ImageView) findViewById(R.id.continueButton);
         Button mapButton = (Button) findViewById(R.id.mapButton);
+        TextView scenarioName = (TextView) findViewById(R.id.scenarioName);
+        if (bundle != null) {
+            scenarioName.setText(String.format(getString(R.string.current_scenario_name),
+                    bundle.getString(getString(R.string.scene))));
+        }
         mapButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -66,7 +72,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
                 startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
             }
         });
-        if (getIntent().getExtras()!=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE))){
+        if (bundle != null && PowerUpUtils.MAP.equals(bundle.getString(PowerUpUtils.SOURCE))) {
             continueButton.setVisibility(View.GONE);
             continueButton.setOnClickListener(null);
         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
@@ -33,6 +33,7 @@ public class VocabMatchEndActivity extends AppCompatActivity {
 
     public void continuePressed(View view){
         Intent intent = new Intent(VocabMatchEndActivity.this, ScenarioOverActivity.class);
+        intent.putExtra(getString(R.string.scene), getString(R.string.hospital));
         finish();
         startActivity(intent);
     }

--- a/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_scenario_over.xml
@@ -53,4 +53,13 @@
         android:textSize="@dimen/karma_points_textSize"
         android:textColor="@color/powerup_black"/>
 
+    <TextView
+        android:id="@+id/scenarioName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/karma_star"
+        android:layout_centerHorizontal="true"
+        android:textAppearance="@style/TextAppearance.AppCompat.Title"
+        android:textColor="@color/score_color"
+        android:textStyle="bold" />
 </RelativeLayout>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="current_scenario_name">Current Scenario: %s</string>
 </resources>


### PR DESCRIPTION
### Description
Add a `TextView` to the **ScenarioOverActivity** to display the scenario name.

Fixes #853

### Type of Change:
- Code
- User Interface
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### Checklist:

- [x] My PR follows the style guidelines for this project
- [x] I have performed a self-review of my own code or materials
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes


**Nexus 7 (resolution: 1200 x 1920: xhdpi, width: 144mm)**
![image](https://user-images.githubusercontent.com/28915865/34905705-82d5d0fc-f884-11e7-915c-093cc63628ef.png)

**Pixel 2 XL (resolution: 1440 x 2880: 560dpi, width: 76.7mm)**
![image](https://user-images.githubusercontent.com/28915865/34905707-8cda90e2-f884-11e7-9527-0d54491c5acb.png)

**Pixel XL (resolution: 1440 x 2560: 560dpi, width: 75.74mm)**
![image](https://user-images.githubusercontent.com/28915865/34905709-9607a47a-f884-11e7-9b1f-e6578ff2bbc7.png)

**Nexus 5 (resolution: 1080 x 1920: xxhdpi, width: 69.2mm)** 
![image](https://user-images.githubusercontent.com/28915865/34905700-6461650a-f884-11e7-9061-2907ba8663ce.png)