### PR TITLE
Program:GCI Add Ripple effect on selecting dialogue

### DIFF
--- a/PowerUp/app/src/main/res/drawable-v21/ripple_effect.xml
+++ b/PowerUp/app/src/main/res/drawable-v21/ripple_effect.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:color="@android:color/darker_gray"
+    tools:targetApi="lollipop">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/darker_gray" />
+        </shape>
+    </item>
+</ripple>

--- a/PowerUp/app/src/main/res/drawable/ripple_effect.xml
+++ b/PowerUp/app/src/main/res/drawable/ripple_effect.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" android:color="@android:color/darker_gray">
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="@android:color/darker_gray"></solid>
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="@android:color/darker_gray"></solid>
+        </shape>
+    </item>
+</selector>

--- a/PowerUp/app/src/main/res/layout-land/game_activity.xml
+++ b/PowerUp/app/src/main/res/layout-land/game_activity.xml
@@ -96,7 +96,8 @@
         android:layout_toRightOf="@id/relativeLayout"
         android:layout_centerVertical="true"
         android:background="@drawable/left_conversation"
-        android:clickable="true"/>
+        android:clickable="true"
+        android:listSelector="@drawable/ripple_effect"/>
     <TextView
         android:textColor="@color/powerup_black"
         android:id="@+id/questionView"


### PR DESCRIPTION
### Description
I have added ripple effect on selecting dialogue when answering the questions in Game Activity.

### Functionality
As ripple effect is supported for API 21 and above, so that's why I have added ripple effect for that and for older android version devices this effect is not applicable.

Fixes # https://github.com/systers/powerup-android/issues/903

### GIF
![img_0250](https://user-images.githubusercontent.com/30840527/34904226-7cb53202-f867-11e7-966d-4adfabd79f1e.GIF)
