### PR TITLE
Program:GCI Implementation of green tick rectified

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
@@ -342,8 +342,12 @@ public class StoreActivity extends AppCompatActivity {
             int id = calculatePosition(position)+1;
 
             if (getPurchasedStatus(id) == 1) { // whatever type is currently opened, it is already bought
+                if (getSelectedItem() == id ){
+                    holder.itemImage.setImageResource(R.drawable.store_tick);
+                } else {
+                    holder.itemImage.setImageResource(android.R.color.transparent);
+                }
                 storeItem.setBackground(getResources().getDrawable(R.drawable.sold_item));
-                holder.itemImage.setImageResource(R.drawable.store_tick);
                 storeItem.setEnabled(true);
             } else { //not purchased => available/not available
                 holder.itemImage.setImageResource(Color.TRANSPARENT);
@@ -384,6 +388,19 @@ public class StoreActivity extends AppCompatActivity {
     public void onBackPressed() {
         finish();
         super.onBackPressed();
+    }
+
+    public int getSelectedItem(){
+        switch (storeItemTypeindex){
+            case PowerUpUtils.HAIR_CODE:
+                return getmDbHandler().getAvatarHair();
+            case PowerUpUtils.CLOTHES_CODE:
+                return getmDbHandler().getAvatarCloth();
+            case PowerUpUtils.ACCESSORY_CODE:
+                return getmDbHandler().getAvatarAccessory();
+            default:
+                throw new IllegalArgumentException(String.valueOf(storeItemTypeindex) + getResources().getString(R.string.iae_store_type_index));
+        }
     }
 }
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -20,6 +20,9 @@ public class PowerUpUtils {
     public static final String MAP = "map";
     public static final String SOURCE = "source";
 
+    public static final int HAIR_CODE = 0;
+    public static final int CLOTHES_CODE = 1;
+    public static final int ACCESSORY_CODE = 2;
 
     public static final String CALLED_BY = "TUTORIALS_ACTIVITY";
     public static final String ID_REFERENCE = "powerup.systers.com.powerup:id/imageView";

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="start_dialog_message">If you start a new game, previous data and all karma points will be lost !</string>
     <string name="start_title_message">Are you Sure ?</string>
     <string name="start_confirm_message">Create new Avatar</string>
+    <string name="iae_store_type_index">is an invalid storeItem type index.</string>
 </resources>


### PR DESCRIPTION
When the user selects a different item in the store, the green tick will only display on the selected item, and not all previously selected items as well. Fixes issue #881 
![screenshot_2018-01-15-02-36-13 1](https://user-images.githubusercontent.com/24259630/34922782-36b7d9f8-f99d-11e7-8b26-8ebe230ec7a1.png)
