### PR TITLE
Implemented next and previous arrows

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
@@ -110,6 +110,7 @@ public class StoreActivity extends AppCompatActivity {
                 currentPage = 0;
                 storeItemTypeindex = 0;
                 adapter.refresh(allDataSet.get(storeItemTypeindex).subList(0, 6));
+                setArrows();
             }
         });
 
@@ -119,6 +120,7 @@ public class StoreActivity extends AppCompatActivity {
                 currentPage = 0;
                 storeItemTypeindex = 1;
                 adapter.refresh(allDataSet.get(storeItemTypeindex).subList(0, PowerUpUtils.CLOTHES_IMAGES.length%6));
+                setArrows();
             }
         });
 
@@ -134,17 +136,14 @@ public class StoreActivity extends AppCompatActivity {
         leftArrow.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (currentPage == 0) {
-                    return;
-                }
                 currentPage--;
-                if (currentPage * 6 < allDataSet.get(storeItemTypeindex).size()) {
-                    if (allDataSet.get(storeItemTypeindex).size() >= currentPage * 6 + 6) {
+                setArrows();
+                if (allDataSet.get(storeItemTypeindex).size() >= currentPage * 6 + 6) {
                         adapter.refresh(allDataSet.get(storeItemTypeindex).subList(currentPage * 6, currentPage * 6 + 6));
-                    } else {
-                        adapter.refresh(allDataSet.get(storeItemTypeindex).subList(currentPage * 6, allDataSet.get(storeItemTypeindex).size()));
+                    }else {
+                    adapter.refresh(allDataSet.get(storeItemTypeindex).subList(currentPage * 6, allDataSet.get(storeItemTypeindex).size()));
                     }
-                }
+
             }
         });
 
@@ -152,14 +151,11 @@ public class StoreActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 currentPage++;
-                if (currentPage * 6 < allDataSet.get(storeItemTypeindex).size()) {
-                    if (allDataSet.get(storeItemTypeindex).size() >= currentPage * 6 + 6) {
-                        adapter.refresh(allDataSet.get(storeItemTypeindex).subList(currentPage * 6, currentPage * 6 + 6));
-                    } else {
-                        adapter.refresh(allDataSet.get(storeItemTypeindex).subList(currentPage * 6, allDataSet.get(storeItemTypeindex).size()));
-                    }
+                  setArrows();
+                if (allDataSet.get(storeItemTypeindex).size() >= currentPage * 6 + 6    ) {
+                           adapter.refresh(allDataSet.get(storeItemTypeindex).subList(currentPage * 6, currentPage * 6 + 6));
                 } else {
-                    currentPage--;
+                    adapter.refresh(allDataSet.get(storeItemTypeindex).subList(currentPage * 6, allDataSet.get(storeItemTypeindex).size()));
                 }
             }
         });
@@ -168,6 +164,7 @@ public class StoreActivity extends AppCompatActivity {
         createDataLists();
         adapter = new GridAdapter(this, allDataSet.get(0).subList(0, 6));
         gridView.setAdapter(adapter);
+        setArrows();
     }
 
     public void setAvatarHair(int index){
@@ -374,6 +371,19 @@ public class StoreActivity extends AppCompatActivity {
 
     public DatabaseHandler getmDbHandler() {
         return mDbHandler;
+    }
+
+    public void setArrows(){
+        if (currentPage==0){
+            leftArrow.setVisibility(View.GONE);
+        }else {
+            leftArrow.setVisibility(View.VISIBLE);
+        }
+        if((currentPage+1)*6 >= allDataSet.get(storeItemTypeindex).size()){
+            rightArrow.setVisibility(View.GONE);
+        }else{
+            rightArrow.setVisibility(View.VISIBLE);
+        }
     }
 
     public void setmDbHandler(DatabaseHandler mDbHandler) {


### PR DESCRIPTION
Arrows appear on either side only if necessary

### Description
Rectified the implementation of left arrow such that it is only visible if more items are present before the items that are viewed currently and similarly for the right arrow.


### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
It has been tested on the emulator.

### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 

