### PR TITLE
Reducing Overdraw by removing app background

### DIFF
--- a/PowerUp/app/src/main/res/values-v11/styles.xml
+++ b/PowerUp/app/src/main/res/values-v11/styles.xml
@@ -6,6 +6,7 @@
     -->
     <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
+        <item name="android:windowBackground"></item>
     </style>
 
 </resources>

--- a/PowerUp/app/src/main/res/values-v14/styles.xml
+++ b/PowerUp/app/src/main/res/values-v14/styles.xml
@@ -7,6 +7,7 @@
     -->
     <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
+        <item name="android:windowBackground"></item>
     </style>
 
 </resources>

--- a/PowerUp/app/src/main/res/values/styles.xml
+++ b/PowerUp/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
     -->
     <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <item name="android:textAllCaps">false</item>
+        <item name="android:windowBackground"></item>
         <!--
             Theme customizations available in newer API levels can go in
             res/values-vXX/styles.xml, while customizations related to


### PR DESCRIPTION
I reduced overdraw of the app by setting the default background to null.

Attached please find the report:
[Reducing Overdraw.docx](https://github.com/systers/powerup-android/files/1633764/Reducing.Overdraw.docx)
