### PR TITLE
Removed error generated when trying to access acc_avatar0 in GameActivity

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -127,15 +127,17 @@ public class GameActivity extends Activity {
 
         getmDbHandler().setAvatarAccessory(getmDbHandler().getAvatarAccessory());
         String accessoryImageName = getResources().getString(R.string.accessories);
-        accessoryImageName = accessoryImageName + getmDbHandler().getAvatarAccessory();
-        try {
-            photoNameField = ourRID.getClass().getField(accessoryImageName);
-            accessoryImageView.setImageResource(photoNameField.getInt(ourRID));
-        } catch (NoSuchFieldException | IllegalAccessException
-                | IllegalArgumentException error) {
-            error.printStackTrace();
+        int index = getmDbHandler().getAvatarAccessory();
+        if (index!=0) {
+            accessoryImageName = accessoryImageName + index;
+            try {
+                photoNameField = ourRID.getClass().getField(accessoryImageName);
+                accessoryImageView.setImageResource(photoNameField.getInt(ourRID));
+            } catch (NoSuchFieldException | IllegalAccessException
+                    | IllegalArgumentException error) {
+                error.printStackTrace();
+            }
         }
-
         // Update Scene
         updateScenario(0);
         updateQA();


### PR DESCRIPTION
### Description

Removed error generated when playing game scenes without buying any accesories, i.e. trying to access acc_avatar0. 

Fixes issue #975 

### Type of Change:
- Code
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
With error - 
![powerup_accessory](https://user-images.githubusercontent.com/24635701/35858166-808ce264-0b61-11e8-8a77-b22b07d3cfd7.png)

Without error - 
![accesory_error_removed](https://user-images.githubusercontent.com/24635701/35858171-85b29e96-0b61-11e8-83a0-2c05818bc657.png)


### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
