### PR TITLE
Fixes #500 replay to launch correct scenario

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -284,6 +284,10 @@ public class AvatarRoomActivity extends Activity {
                 SessionHistory.totalPoints = 0;    //reset the points stored
                 SessionHistory.currSessionID = 1;
                 SessionHistory.currScenePoints = 0;
+                SessionHistory.sceneHomeIsReplayed = false;
+                SessionHistory.sceneSchoolIsReplayed = false;
+                SessionHistory.sceneHospitalIsReplayed = false;
+                SessionHistory.sceneLibraryIsReplayed = false;
                 finish();
                 startActivity(new Intent(AvatarRoomActivity.this, FinalAvatarActivity.class));
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -14,6 +14,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.ImageView;
 
+import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.minesweeper.MinesweeperGameActivity;
 import powerup.systers.com.minesweeper.MinesweeperSessionManager;
@@ -44,6 +45,7 @@ public class MapActivity extends Activity {
                 } else {
                     Intent intent = new Intent(MapActivity.this, ScenarioOverActivity.class);
                     intent.putExtra(PowerUpUtils.SOURCE,PowerUpUtils.MAP);
+                    intent.putExtra(PowerUpUtils.SCENARIO_NAME,getScenarioName(scenarioChooser.getId()));
                     startActivityForResult(intent, 0);
                     overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                 }
@@ -116,15 +118,15 @@ public class MapActivity extends Activity {
         });
 
         //changes the Map building's greyscale color and locks according to the scenarios completions
-        if (getmDbHandler().getScenarioFromID(4).getCompleted() == 1){
+        if (getmDbHandler().getScenarioFromID(4).getCompleted() == 1 || SessionHistory.sceneHomeIsReplayed){
             schoolBuilding.setImageDrawable(getResources().getDrawable(R.drawable.school_colored));
             school.setEnabled(true);
         }
-        if (getmDbHandler().getScenarioFromID(5).getCompleted() == 1){
+        if (getmDbHandler().getScenarioFromID(5).getCompleted() == 1 || SessionHistory.sceneSchoolIsReplayed){
             hospitalBuilding.setImageDrawable(getResources().getDrawable(R.drawable.hospital_colored));
             hospital.setEnabled(true);
         }
-        if (getmDbHandler().getScenarioFromID(6).getCompleted() == 1){
+        if (getmDbHandler().getScenarioFromID(6).getCompleted() == 1 || SessionHistory.sceneHospitalIsReplayed){
             libraryBuilding.setImageDrawable(getResources().getDrawable(R.drawable.library_colored));
             library.setEnabled(true);
         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -63,7 +63,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
         getmDbHandler().open();
         setContentView(R.layout.activity_scenario_over);
         scene = getmDbHandler().getScenario();
-        Scenario prevScene = getmDbHandler().getScenarioFromID(SessionHistory.prevSessionID); //Fetching Scenario
+        final Scenario prevScene = getmDbHandler().getScenarioFromID(SessionHistory.prevSessionID); //Fetching Scenario
         scenarioActivityDone = 1;
         if(!new ScenarioOverActivity(this).isActivityOpened()){
             dialogMaker();
@@ -81,9 +81,11 @@ public class ScenarioOverActivity extends AppCompatActivity {
         });
 
         //Initializing and setting Text for currentScenarioName
-        TextView currentScenarioName = (TextView) findViewById(R.id.currentScenarioName);
-        currentScenarioName.setText(getResources().
-                getString(R.string.current_scenario_name,prevScene.getScenarioName()));
+        final TextView currentScenarioName = (TextView) findViewById(R.id.currentScenarioName);
+        if(getIntent().getExtras() !=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE)) && getIntent().getStringExtra(PowerUpUtils.SCENARIO_NAME) != null)
+            currentScenarioName.setText(getResources().getString(R.string.current_scenario_name,getIntent().getStringExtra(PowerUpUtils.SCENARIO_NAME)));
+        else
+            currentScenarioName.setText(getResources().getString(R.string.current_scenario_name,prevScene.getScenarioName()));
         TextView karmaPoints = (TextView) findViewById(R.id.karmaPoints);
         
         karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
@@ -109,8 +111,35 @@ public class ScenarioOverActivity extends AppCompatActivity {
         replayButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                SessionHistory.currSessionID = SessionHistory.prevSessionID;
-                //Check that reducing points does not lead to negetive value
+                if(getIntent().getExtras() !=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE)) && getIntent().getStringExtra(PowerUpUtils.SCENARIO_NAME) != null) {
+                    String scenario = getIntent().getStringExtra(PowerUpUtils.SCENARIO_NAME);
+                    int id;
+                    switch (scenario) {
+                        case "Home":
+                            id = 4;
+                            SessionHistory.sceneHomeIsReplayed = true;
+                            break;
+                        case "School":
+                            id = 5;
+                            SessionHistory.sceneSchoolIsReplayed = true;
+                            break;
+                        case "Hospital":
+                            id = 6;
+                            SessionHistory.sceneHospitalIsReplayed = true;
+                            break;
+                        case "Library":
+                            id = 7;
+                            SessionHistory.sceneLibraryIsReplayed = true;
+                            break;
+                        default:
+                            id = 4;
+                            break;
+                        }
+                    SessionHistory.currSessionID = id;
+                    } else {
+                    SessionHistory.currSessionID = SessionHistory.prevSessionID;
+                    scenarioActivityDone = 0;
+                    }                //Check that reducing points does not lead to negetive value
                 if(SessionHistory.totalPoints - SessionHistory.currScenePoints >= 0)
                 SessionHistory.totalPoints -= SessionHistory.currScenePoints;
                 SessionHistory.currScenePoints = 0;

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/SessionHistory.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/SessionHistory.java
@@ -19,4 +19,8 @@ public class SessionHistory {
     public static int hatTotalNo = 4;
     public static int necklaceTotalNo = 4;
     public static int accessoryTotalNo = 4;
+    public static boolean sceneHomeIsReplayed = false;
+    public static boolean sceneSchoolIsReplayed = false;
+    public static boolean sceneHospitalIsReplayed = false;
+    public static boolean sceneLibraryIsReplayed = false;
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/powerup/PowerUpUtils.java
@@ -22,6 +22,7 @@ public class PowerUpUtils {
     public static final String WRONG_ANSWER = "wrong";
     public static final String MAP = "map";
     public static final String SOURCE = "source";
+    public static final String SCENARIO_NAME = "scenario_name";
 
 
     public static final String CALLED_BY = "TUTORIALS_ACTIVITY";


### PR DESCRIPTION
### Description

Rectified the handling of replay button such that correct scene is launched after clicking the replay button.
An intent extra with the name of the scenario clicked on the map is passed to ScenarioOverActivty.
With the help of switch case block the scenario which was clicked on is identified and that particular scenario is launched accordingly.
Boolean variables sceneHomeIsReplayed, sceneSchoolIsReplayed, sceneHospitalIsReplayed and sceneLibraryIsReplayed are defined in SessionHistory.java which is set to true if the clicked upon scenario is already played and is replayed. The basic utility of variables is to take care that the next scene in the queue does not get grayed out on map if the selected scene to be replayed is left in the middle.
An if-else block:
```
if(getIntent().getExtras() !=null && PowerUpUtils.MAP.equals(getIntent().getExtras().getString(PowerUpUtils.SOURCE)) && getIntent().getStringExtra(PowerUpUtils.SCENARIO_NAME) != null)
        currentScenarioName.setText(getResources().getString(R.string.current_scenario_name,getIntent().getStringExtra(PowerUpUtils.SCENARIO_NAME)));
        else
            currentScenarioName.setText(getResources().getString(R.string.current_scenario_name,prevScene.getScenarioName())); 
```
is added so that the scenario name in the scenario over activity is updated properly.

Fixes #500

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

All the changes have been testsed on Android Studio emulator.
Steps to reproduce the changes:
    1.Complete the whole game
    2.Migrate to Map
    3.Choose a scenario to be replayed
    4.Click on Replay button
    5.(Fix) The chosen scenario is replayed

### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
