### PR TITLE
Fixes #530 Inconsistent display of score

### DIFF
--- a/PowerUp/app/src/main/res/layout/activity_sink_to_swim_game.xml
+++ b/PowerUp/app/src/main/res/layout/activity_sink_to_swim_game.xml
@@ -123,7 +123,7 @@
                 android:layout_height="0dp"
                 android:layout_weight="2"
                 android:gravity="center|top"
-                android:text="Score: 00"
+                android:text="@string/score_text_zero"
                 android:textColor="#FFFFFF"
                 android:textSize="@dimen/question_textSize"
                 android:textStyle="bold" />

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -87,4 +87,5 @@
     <string name="game_to_map_message">If you migrate to map, current scene karma points will be lost</string>
     <string name="game_confirm_message">Go to Map</string>
     <string name="marcello_Text">Marcello</string>
+    <string name="score_text_zero">Score: 0</string>
 </resources>


### PR DESCRIPTION
### Description
Initially when the game starts the score in the game is diaplyed with two digits,that is, two zeros.
But just after first response from the user, the score is displayed with just one digit.
If the user pressed the skip button or the answer by the user is wrong, the double digit of the score,that is, double zeros of the score are set to a single zero.
If the user answers correctly, the double zeros are set to a single one.
Fxed the issue by adding relevant string resource.

Fixes #530 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran the app again on Redmi Note 4 to verify the UI change.

### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
