### PR TITLE
Fix #524 Negative karma points

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -115,6 +115,8 @@ public class ScenarioOverActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 SessionHistory.currSessionID = SessionHistory.prevSessionID;
+                //Check that reducing points does not lead to negetive value
+                if(SessionHistory.totalPoints - SessionHistory.currScenePoints >= 0)
                 SessionHistory.totalPoints -= SessionHistory.currScenePoints;
                 SessionHistory.currScenePoints = 0;
                 scenarioActivityDone = 0;


### PR DESCRIPTION
### Description
An if statement is add before the deduction of karma points in ScenarioOverActivity.java
``` 
if(SessionHistory.totalPoints - SessionHistory.currScenePoints >= 0)
                SessionHistory.totalPoints -= SessionHistory.currScenePoints; 
```
The major purpose of if statement is that the karma points will be deducted only if deduction does not gives rise to a negative value

Fixes #524 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
The changes have been tested on android studio emulator

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
