### PR TITLE
Fixes #1006 Cancel option in warning dialog

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -336,6 +336,8 @@ public class GameActivity extends Activity {
         });
         builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
+                goToMap.setAlpha(1f);
+                goToMap.setClickable(true);
                 dialog.dismiss();
             }
         });


### PR DESCRIPTION
### Description
Implementation of home button is fixed such that it doesnot disappear after presseing cancel on warning dialog

Fixes #1006 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
The changes have been tested on Android Studio emulator
![home button](https://user-images.githubusercontent.com/26908195/37364673-2c90f37c-2721-11e8-9d7f-726537b523f2.gif)

### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
