### PR TITLE
Usage of "dp" for text size

### DIFF
--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -154,7 +154,7 @@
     <dimen name="pgame_quesitionView_marginLeft">20dp</dimen>
     <dimen name="hair_eyes_face_clothes">15sp</dimen>
     <dimen name="about_text_size_title">40sp</dimen>
-    <dimen name="about_text_size_section_title">20dp</dimen>
+    <dimen name="about_text_size_section_title">20sp</dimen>
     <dimen name="about_text_size_section_content">16sp</dimen>
     <dimen name="about_side_padding">40dp</dimen>
     <dimen name="about_top_bottom_padding">50dp</dimen>


### PR DESCRIPTION
### Description

Changes made in dimen.xml, in "about_text_size_section_title" it has been changed as sp - "scale-independent-pixels" instead of dp.

Fixes #534 

### Type of Change:

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been published in downstream modules
