### PR TITLE
Fixes issue #703 Changed access public to private

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -13,14 +13,11 @@ import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.ImageView;
 
-import java.util.Random;
-
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 
 public class AvatarRoomActivity extends Activity {
 
-    public Activity avatarRoomInstance;
     private DatabaseHandler mDbHandler;
     private ImageView eyeAvatar;
     private ImageView skinAvatar;
@@ -32,7 +29,6 @@ public class AvatarRoomActivity extends Activity {
     private Integer cloth;
 
     public AvatarRoomActivity() {
-        avatarRoomInstance = this;
     }
 
     public void onCreate(Bundle savedInstanceState) {
@@ -294,11 +290,11 @@ public class AvatarRoomActivity extends Activity {
         getmDbHandler().close();
     }
 
-    public DatabaseHandler getmDbHandler() {
+    private DatabaseHandler getmDbHandler() {
         return mDbHandler;
     }
 
-    public void setmDbHandler(DatabaseHandler mDbHandler) {
+    private void setmDbHandler(DatabaseHandler mDbHandler) {
         this.mDbHandler = mDbHandler;
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/FinalAvatarActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/FinalAvatarActivity.java
@@ -11,9 +11,9 @@ import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.ImageView;
 
-import java.util.Random;
 
-import powerup.systers.com.datamodel.SessionHistory;
+
+
 import powerup.systers.com.db.DatabaseHandler;
 
 public class FinalAvatarActivity extends Activity{
@@ -22,10 +22,10 @@ public class FinalAvatarActivity extends Activity{
     private ImageView clothAvatar;
     private ImageView hairAvatar;
     private DatabaseHandler mDbHandler;
-    public Activity finalAvatarInstance;
-    public FinalAvatarActivity() {
-        finalAvatarInstance = this;
-    }
+
+
+
+    
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -100,11 +100,12 @@ public class FinalAvatarActivity extends Activity{
             }
         });
     }
-    public DatabaseHandler getmDbHandler() {
+    private DatabaseHandler getmDbHandler() {
         return mDbHandler;
     }
 
-    public void setmDbHandler(DatabaseHandler mDbHandler) {
+    private void setmDbHandler(DatabaseHandler mDbHandler) {
         this.mDbHandler = mDbHandler;
     }
 }
+

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -57,7 +57,7 @@ public class GameActivity extends Activity {
     private Button goToMap;
     private ArrayAdapter<String> listAdapter;
     private static boolean isStateChanged = false;
-    Context context;
+    private Context context;
 
     public GameActivity() {
         gameActivityInstance = this;
@@ -307,11 +307,11 @@ public class GameActivity extends Activity {
         questionTextView.setText(questions.getQuestionDescription());
     }
 
-    public DatabaseHandler getmDbHandler() {
+    private DatabaseHandler getmDbHandler() {
         return mDbHandler;
     }
 
-    public void setmDbHandler(DatabaseHandler mDbHandler) {
+    private void setmDbHandler(DatabaseHandler mDbHandler) {
         this.mDbHandler = mDbHandler;
     }
 
@@ -325,7 +325,7 @@ public class GameActivity extends Activity {
         startActivity(new Intent(GameActivity.this, MapActivity.class).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
         finish();
     }
-    public void gotToMapDialogue(){
+    private void gotToMapDialogue(){
         AlertDialog.Builder builder = new AlertDialog.Builder(GameActivity.this);
         builder.setTitle(context.getResources().getString(R.string.start_title_message))
                 .setMessage(getResources().getString(R.string.game_to_map_message));

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -131,11 +131,11 @@ public class MapActivity extends Activity {
 
     }
 
-    public DatabaseHandler getmDbHandler() {
+    private DatabaseHandler getmDbHandler() {
         return mDbHandler;
     }
 
-    public void setmDbHandler(DatabaseHandler mDbHandler) {
+    private void setmDbHandler(DatabaseHandler mDbHandler) {
         this.mDbHandler = mDbHandler;
     }
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ScenarioOverActivity.java
@@ -24,39 +24,30 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.Button;
-import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import com.akexorcist.roundcornerprogressbar.IconRoundCornerProgressBar;
 
 import powerup.systers.com.datamodel.Scenario;
-import powerup.systers.com.datamodel.Score;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.powerup.PowerUpUtils;
-
-import static powerup.systers.com.R.string.scenario_description;
-import static powerup.systers.com.R.string.scene;
 
 public class ScenarioOverActivity extends AppCompatActivity {
 
     public Activity scenarioOverActivityInstance;
     public static int scenarioActivityDone;
     private DatabaseHandler mDbHandler;
-    public Scenario scene;
     private final String PREF_NAME_SCENARIO = "SCENARIO_OVER_DIALOG";
     private final int PRIVATE_MODE_SCENARIO = 0;
     private final String GAME_OPENED_SCENARIO = "IS_GAME_REPLAYED";
-    SharedPreferences sharedPreferences_scenario;
-    Context context_scenario;
-    SharedPreferences.Editor editor_scenario;
+    private SharedPreferences sharedPreferences_scenario;
+    private SharedPreferences.Editor editor_scenario;
 
     public ScenarioOverActivity() {
         scenarioOverActivityInstance = this;
     }
     public ScenarioOverActivity(Context context){
-        this.context_scenario = context;
         sharedPreferences_scenario = context.getSharedPreferences(PREF_NAME_SCENARIO, PRIVATE_MODE_SCENARIO);
         editor_scenario = sharedPreferences_scenario.edit();
     }
@@ -67,7 +58,6 @@ public class ScenarioOverActivity extends AppCompatActivity {
         setmDbHandler(new DatabaseHandler(this));
         getmDbHandler().open();
         setContentView(R.layout.activity_scenario_over);
-        scene = getmDbHandler().getScenario();
         Scenario prevScene = getmDbHandler().getScenarioFromID(SessionHistory.prevSessionID); //Fetching Scenario
         scenarioActivityDone = 1;
         if(!new ScenarioOverActivity(this).isActivityOpened()){
@@ -139,7 +129,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
         finish();
     }
 
-    public void dialogMaker() {
+    private void dialogMaker() {
         int width = (int)(getResources().getDisplayMetrics().widthPixels*0.43);
         String scenario_over_dialog_message = getResources().getString(R.string.scenario_over_dialog_message1);
         String scenario_over_dialog_message2 = getResources().getString(R.string.scenario_over_dialog_message2);
@@ -179,7 +169,7 @@ public class ScenarioOverActivity extends AppCompatActivity {
         leftSpacer.setVisibility(View.GONE);
     }
 
-    public boolean isActivityOpened() {
+    private boolean isActivityOpened() {
         return sharedPreferences_scenario.getBoolean(GAME_OPENED_SCENARIO, false);
     }
 
@@ -189,11 +179,11 @@ public class ScenarioOverActivity extends AppCompatActivity {
         editor_scenario.commit();
     }
 
-    public DatabaseHandler getmDbHandler() {
+    private DatabaseHandler getmDbHandler() {
         return mDbHandler;
     }
 
-    public void setmDbHandler(DatabaseHandler mDbHandler) {
+    private void setmDbHandler(DatabaseHandler mDbHandler) {
         this.mDbHandler = mDbHandler;
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -36,8 +36,8 @@ public class StartActivity extends Activity {
     private Button startButton;
     private Button newUserButton;
     private Button aboutButton;
-    Context context;
-    boolean backAlreadyPressed = false;
+    private Context context;
+    private boolean backAlreadyPressed = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
@@ -1,5 +1,6 @@
 package powerup.systers.com;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -7,7 +8,6 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -17,12 +17,9 @@ import android.view.ViewGroup;
 import android.widget.AbsListView;
 import android.widget.BaseAdapter;
 import android.widget.Button;
-import android.widget.FrameLayout;
 import android.widget.GridView;
 import android.widget.ImageView;
 import android.widget.TextView;
-
-import org.w3c.dom.Text;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,19 +32,22 @@ import powerup.systers.com.powerup.PowerUpUtils;
 
 public class StoreActivity extends AppCompatActivity {
 
-    GridView gridView;
-    public int storeItemTypeindex = 0;
-    public int currentPage = 0;
-    int screenWidth, screenHeight;
-    ImageView clothImageView, hairImageView, accessoryImageView;
-    ImageView leftArrow, rightArrow, hairButton, clothesButton, accessoriesButton;
-    List<List<StoreItem>> allDataSet;
-    GridAdapter adapter;
-    TextView karmaPoints;
+    private int storeItemTypeindex = 0;
+    private int currentPage = 0;
+    private int screenWidth;
+    private int screenHeight;
+    private ImageView clothImageView;
+    private ImageView hairImageView;
+    private ImageView accessoryImageView;
+    private ImageView leftArrow;
+    private ImageView rightArrow;
+    private List<List<StoreItem>> allDataSet;
+    private GridAdapter adapter;
+    private TextView karmaPoints;
     private DatabaseHandler mDbHandler;
-    java.lang.reflect.Field photoNameField;
-    R.drawable ourRID;
-    long selectedItemId;
+    private java.lang.reflect.Field photoNameField;
+    private R.drawable ourRID;
+    private long selectedItemId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -106,9 +106,9 @@ public class StoreActivity extends AppCompatActivity {
 
         leftArrow = (ImageView) findViewById(R.id.left_arrow);
         rightArrow = (ImageView) findViewById(R.id.right_arrow);
-        hairButton = (ImageView) findViewById(R.id.hair_button);
-        clothesButton = (ImageView) findViewById(R.id.clothes_button);
-        accessoriesButton = (ImageView) findViewById(R.id.accessories_button);
+        ImageView hairButton = (ImageView) findViewById(R.id.hair_button);
+        ImageView clothesButton = (ImageView) findViewById(R.id.clothes_button);
+        ImageView accessoriesButton = (ImageView) findViewById(R.id.accessories_button);
 
         hairButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -168,14 +168,14 @@ public class StoreActivity extends AppCompatActivity {
             }
         });
 
-        gridView = (GridView) findViewById(R.id.grid_view);
+        GridView gridView = (GridView) findViewById(R.id.grid_view);
         createDataLists();
         adapter = new GridAdapter(this, allDataSet.get(0).subList(0, 6));
         gridView.setAdapter(adapter);
         setArrows();
     }
 
-    public void setAvatarHair(int index){
+    private void setAvatarHair(int index){
         getmDbHandler().setAvatarHair(index);
         String hairImageName = getResources().getString(R.string.hair);
         hairImageName = hairImageName + index;
@@ -189,7 +189,7 @@ public class StoreActivity extends AppCompatActivity {
 
     }
 
-    public void setAvatarClothes(int index){
+    private void setAvatarClothes(int index){
         getmDbHandler().setAvatarCloth(index);
         String clothImageName = getResources().getString(R.string.cloth);
         clothImageName = clothImageName + index;
@@ -202,7 +202,7 @@ public class StoreActivity extends AppCompatActivity {
         }
     }
 
-    public void setAvatarAccessories(int index){
+    private void setAvatarAccessories(int index){
         getmDbHandler().setAvatarAccessory(index);
         String accessoryImageName = getResources().getString(R.string.accessories);
         accessoryImageName = accessoryImageName + index;
@@ -215,7 +215,7 @@ public class StoreActivity extends AppCompatActivity {
         }
     }
 
-    public void createDataLists() {
+    private void createDataLists() {
         allDataSet = new ArrayList<>();
 
         List<StoreItem> storeHair = new ArrayList<>();
@@ -241,7 +241,7 @@ public class StoreActivity extends AppCompatActivity {
         }
     }
 
-    public int calculatePosition(int position) {
+    private int calculatePosition(int position) {
         int id = currentPage*6+position;
         return id;
     }
@@ -256,7 +256,7 @@ public class StoreActivity extends AppCompatActivity {
             this.storeItems = list;
         }
 
-        public void refresh(List<StoreItem> updatedList) {
+        private void refresh(List<StoreItem> updatedList) {
             this.storeItems = updatedList;
             notifyDataSetChanged();
         }
@@ -286,6 +286,7 @@ public class StoreActivity extends AppCompatActivity {
             }
         }
 
+        @SuppressLint("ResourceType")
         @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
         @Override
         public View getView(final int position, View convertView, ViewGroup parent) {
@@ -427,7 +428,7 @@ public class StoreActivity extends AppCompatActivity {
         dialog.show();
     }
 
-    public int getPurchasedStatus(int index) {
+    private int getPurchasedStatus(int index) {
         if (storeItemTypeindex == 0) { //hair
             return getmDbHandler().getPurchasedHair(index);
         } else if (storeItemTypeindex == 1) { //clothes
@@ -438,15 +439,15 @@ public class StoreActivity extends AppCompatActivity {
         return 0;
     }
 
-    public DatabaseHandler getmDbHandler() {
+    private DatabaseHandler getmDbHandler() {
         return mDbHandler;
     }
 
-    public void setmDbHandler(DatabaseHandler mDbHandler) {
+    private void setmDbHandler(DatabaseHandler mDbHandler) {
         this.mDbHandler = mDbHandler;
     }
   
-  public void setArrows() {
+  private void setArrows() {
         if(currentPage==0){
             leftArrow.setVisibility(View.GONE);
         } else {

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Avatar.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Avatar.java
@@ -5,7 +5,7 @@
 
 package powerup.systers.com.datamodel;
 
-public class Avatar {
+class Avatar {
     private Integer id;
     private Integer face;
     private Integer eyes;

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Score.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Score.java
@@ -5,11 +5,11 @@
 
 package powerup.systers.com.datamodel;
 
-public class Score {
-    public Integer healing;
-    public Integer strength;
-    public Integer telepathy;
-    public Integer invisibility;
+class Score {
+    private Integer healing;
+    private Integer strength;
+    private Integer telepathy;
+    private Integer invisibility;
 
     public Integer getHealing() {
         return healing;

--- a/PowerUp/app/src/main/java/powerup/systers/com/db/AbstractDbAdapter.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/db/AbstractDbAdapter.java
@@ -15,9 +15,9 @@ import android.database.sqlite.SQLiteOpenHelper;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.sql.Array;
 import java.util.Arrays;
 
+@SuppressWarnings("ALL")
 public abstract class AbstractDbAdapter {
 
     private static final int DATABASE_VERSION = 2;
@@ -26,9 +26,10 @@ public abstract class AbstractDbAdapter {
     private static BufferedReader in;
     private static AssetManager assetManager;
     protected final Context mCtx;
-    protected DatabaseHelper mDbHelper;
 
-    public AbstractDbAdapter(Context ctx) {
+    private DatabaseHelper mDbHelper;
+
+    AbstractDbAdapter(Context ctx) {
         this.mCtx = ctx;
         assetManager = ctx.getAssets();
         mDbHelper = new DatabaseHelper(mCtx);
@@ -45,7 +46,7 @@ public abstract class AbstractDbAdapter {
         }
     }
 
-    protected static class DatabaseHelper extends SQLiteOpenHelper {
+    static class DatabaseHelper extends SQLiteOpenHelper {
 
         DatabaseHelper(Context context) {
             super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -55,7 +56,7 @@ public abstract class AbstractDbAdapter {
 	* @desc enter the default avatar settings into the database.
 	* @param db - the database the avatar will be put into
 	*/
-        public void insertAvatar(SQLiteDatabase db) {
+    public void insertAvatar(SQLiteDatabase db) {
             ContentValues values = new ContentValues();
             values.put(PowerUpContract.AvatarEntry.COLUMN_ID, 1);
             values.put(PowerUpContract.AvatarEntry.COLUMN_FACE, 1);
@@ -74,7 +75,7 @@ public abstract class AbstractDbAdapter {
 	* into the database.
 	* @param db - the database the scores will be put into
 	*/
-        public void insertPoints(SQLiteDatabase db) {
+    private void insertPoints(SQLiteDatabase db) {
             ContentValues values = new ContentValues();
             values.put(PowerUpContract.PointEntry.COLUMN_ID, 1);
             values.put(PowerUpContract.PointEntry.COLUMN_HEALING, 1);
@@ -90,7 +91,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the questions will be put into
 	* @param rowData - the array to read question information from
 	*/
-        public void insertDBQuestion(SQLiteDatabase db, String[] rowData) {
+    private void insertDBQuestion(SQLiteDatabase db, String[] rowData) {
             ContentValues values = new ContentValues();
             // if (rowData.length == 3) {
             values.put(PowerUpContract.QuestionEntry.COLUMN_QUESTION_ID, rowData[0]);
@@ -109,7 +110,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the answers will be put into
 	* @param rowData - the array to read answer information from
 	*/
-        public void insertDBAnswer(SQLiteDatabase db, String[] rowData) {
+    private void insertDBAnswer(SQLiteDatabase db, String[] rowData) {
             ContentValues values = new ContentValues();
             if (rowData.length == 5) {
                 values.put(PowerUpContract.AnswerEntry.COLUMN_ANSWER_ID, rowData[0]);
@@ -131,7 +132,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the scenarios will be put into
 	* @param rowData - the array to read scenario information from
 	*/
-        public void insertDBScenario(SQLiteDatabase db, String[] rowData) {
+    private void insertDBScenario(SQLiteDatabase db, String[] rowData) {
             ContentValues values = new ContentValues();
             if (rowData.length == 7) {
                 values.put(PowerUpContract.ScenarioEntry.COLUMN_ID, rowData[0]);
@@ -156,7 +157,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the clothes will be put into
 	* @param rowData - the array to read clothing information from
 	*/
-        public void insertDBClothes(SQLiteDatabase db, String[] rowData) {
+    private void insertDBClothes(SQLiteDatabase db, String[] rowData) {
             ContentValues values = new ContentValues();
             if (rowData.length == 3) {
                 values.put(PowerUpContract.ClothesEntry.COLUMN_ID, rowData[0]);
@@ -175,7 +176,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the hair will be put into
 	* @param rowData - the array to read hair information from
 	*/
-        public void insertDBHair(SQLiteDatabase db, String[] rowData) {
+    private void insertDBHair(SQLiteDatabase db, String[] rowData) {
             ContentValues values = new ContentValues();
             if (rowData.length == 3) {
                 values.put(PowerUpContract.HairEntry.COLUMN_ID, rowData[0]);
@@ -194,7 +195,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the accessory will be put into
 	* @param rowData - the array to read accessory information from
 	*/
-        public void insertDBAccessories(SQLiteDatabase db, String[] rowData) {
+    public void insertDBAccessories(SQLiteDatabase db, String[] rowData) {
             ContentValues values = new ContentValues();
             if (rowData.length == 3) {
                 values.put(PowerUpContract.AccessoryEntry.COLUMN_ID, rowData[0]);
@@ -213,7 +214,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the question will be put into
 	* @param filename - the file to extract question information from
 	*/
-        public void readCSVQuestion(SQLiteDatabase db, String filename)
+    public void readCSVQuestion(SQLiteDatabase db, String filename)
                 throws IOException {
             in = new BufferedReader(new InputStreamReader(
                     assetManager.open(filename)));
@@ -230,7 +231,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the answer will be put into
 	* @param filename - the file to extract answer information from
 	*/
-        public void readCSVAnswer(SQLiteDatabase db, String filename)
+    private void readCSVAnswer(SQLiteDatabase db, String filename)
                 throws IOException {
             in = new BufferedReader(new InputStreamReader(
                     assetManager.open(filename)));
@@ -247,7 +248,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the scenario will be put into
 	* @param filename - the file to extract scenario information from
 	*/
-        public void readCSVScenario(SQLiteDatabase db, String filename)
+    public void readCSVScenario(SQLiteDatabase db, String filename)
                 throws IOException {
             in = new BufferedReader(new InputStreamReader(
                     assetManager.open(filename)));
@@ -264,7 +265,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the clothes will be put into
 	* @param filename - the file to extract clothing information from
 	*/
-        public void readCSVClothes(SQLiteDatabase db, String filename) throws IOException {
+    public void readCSVClothes(SQLiteDatabase db, String filename) throws IOException {
             in = new BufferedReader(new InputStreamReader(assetManager.open(filename)));
             String reader;
             while ((reader = in.readLine()) != null) {
@@ -279,7 +280,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the hair will be put into
 	* @param filename - the file to extract hair information from
 	*/
-        public void readCSVHair(SQLiteDatabase db, String filename) throws IOException {
+   private void readCSVHair(SQLiteDatabase db, String filename) throws IOException {
             in = new BufferedReader(new InputStreamReader(assetManager.open(filename)));
             String reader;
             while ((reader = in.readLine()) != null) {
@@ -294,7 +295,7 @@ public abstract class AbstractDbAdapter {
 	* @param db - the database the accessories will be put into
 	* @param filename - the file to extract accessory information from
 	*/
-        public void readCSVAccessories(SQLiteDatabase db, String filename) throws IOException {
+   public void readCSVAccessories(SQLiteDatabase db, String filename) throws IOException {
             in = new BufferedReader(new InputStreamReader(assetManager.open(filename)));
             String reader;
             while ((reader = in.readLine()) != null) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/db/PowerUpContract.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/db/PowerUpContract.java
@@ -6,7 +6,7 @@ package powerup.systers.com.db;
 
 import android.provider.BaseColumns;
 
-public class PowerUpContract {
+class PowerUpContract {
 
     public static final class ScenarioEntry implements BaseColumns {
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperGameActivity.java
@@ -1,7 +1,7 @@
 package powerup.systers.com.minesweeper;
 
 import android.animation.Animator;
-import android.content.Context;
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
@@ -19,7 +19,6 @@ import java.util.HashSet;
 import java.util.Random;
 
 import powerup.systers.com.MinesweeperSound;
-import powerup.systers.com.GameOverActivity;
 import powerup.systers.com.MapActivity;
 import powerup.systers.com.R;
 import powerup.systers.com.powerup.PowerUpUtils;
@@ -33,8 +32,7 @@ public class MinesweeperGameActivity extends AppCompatActivity {
 
     public HashSet<String> mines;
     public int score = 0;
-    public int gameRound = 0;
-    public int numRedMines;
+    private int gameRound = 0;
     public int numSelectionsLeft;
     public TextView scoreTextView;
     public ImageView banner;
@@ -75,7 +73,7 @@ public class MinesweeperGameActivity extends AppCompatActivity {
             mines.clear();
         }
         gameRound++;
-        numRedMines = (PowerUpUtils.ROUNDS_FAILURE_PERCENTAGES[gameRound - 1] * PowerUpUtils.NUMBER_OF_CELLS) / 100;
+        int numRedMines = (PowerUpUtils.ROUNDS_FAILURE_PERCENTAGES[gameRound - 1] * PowerUpUtils.NUMBER_OF_CELLS) / 100;
         while (mines.size() != numRedMines) { //add red mines randomly and store them in mines
             Random random = new Random();
             mines.add(PowerUpUtils.ID_REFERENCE + Math.abs(random.nextInt() % 25));
@@ -140,9 +138,10 @@ public class MinesweeperGameActivity extends AppCompatActivity {
      * opened mine is green, increment the score
      * includes zoom in and out bounce animation on score
      */
+    @SuppressLint("ResourceType")
     public void openedGreenMine() {
         playSound(MinesweeperSound.TYPE_CORRECT);
-        Animation animation = AnimationUtils.loadAnimation(getApplicationContext(), R.animator.zoom_in);
+        @SuppressLint("ResourceType") Animation animation = AnimationUtils.loadAnimation(getApplicationContext(), R.animator.zoom_in);
         scoreTextView.startAnimation(animation);
         score++;
         scoreTextView.setText("Score: " + score);
@@ -204,7 +203,7 @@ public class MinesweeperGameActivity extends AppCompatActivity {
                 drawable = getResources().getDrawable(R.drawable.red_star);
             } else {
                 drawable = getResources().getDrawable(R.drawable.green_star);
-                setImageButtonEnabled(this, false, mine, drawable); //calls grey out animation on all green mines
+                setImageButtonEnabled(false, mine, drawable); //calls grey out animation on all green mines
             }
             mine.setImageDrawable(drawable);
             mine.setEnabled(false);
@@ -217,7 +216,7 @@ public class MinesweeperGameActivity extends AppCompatActivity {
      * @param enabled false if mine is disabled i.e. greyed out animation
      * @param item mine imageview which has to be greyed out
      */
-    public void setImageButtonEnabled(Context ctxt, boolean enabled, ImageView item, Drawable originalIcon) {
+    private void setImageButtonEnabled(boolean enabled, ImageView item, Drawable originalIcon) {
         item.setAlpha(0.8f);
         Drawable res = originalIcon.mutate();
         if (enabled) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperSessionManager.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperSessionManager.java
@@ -15,16 +15,15 @@ public class MinesweeperSessionManager {
     private final int PRIVATE_MODE = 0;
     private final String GAME_OPENED = "IS_MINESWEEPER_OPENED";
 
-    SharedPreferences pref;
-    Context context;
-    SharedPreferences.Editor editor;
+    private SharedPreferences pref;
+    private SharedPreferences.Editor editor;
 
     /**
      * @desc Returns the object of SessionManager through which session changes can be made
      * @param context - context of the calling activity
      */
     public MinesweeperSessionManager(Context context) {
-        this.context = context;
+
         pref = context.getSharedPreferences(PREF_NAME, PRIVATE_MODE);
         editor = pref.edit();
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperTutorials.java
@@ -12,8 +12,8 @@ import powerup.systers.com.powerup.PowerUpUtils;
 
 public class MinesweeperTutorials extends AppCompatActivity {
 
-    ImageView tutorialView;
-    int curTutorialImage;
+    private ImageView tutorialView;
+    private int curTutorialImage;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
@@ -15,7 +15,9 @@ public class ProsAndConsActivity extends AppCompatActivity {
 
     public int completedRounds;
     public int score;
-    public TextView proOne, proTwo, conOne;
+    private TextView proOne;
+    private TextView proTwo;
+    private TextView conOne;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimGame.java
@@ -35,17 +35,22 @@ public class SinkToSwimGame extends AppCompatActivity {
 
     public ImageView pointer, boat;
     public int height;
-    public Animation mAnimation;
-    public int score, curQuestion, speed, correctAnswers, wrongAnswers;
+    public int score;
+    public int curQuestion;
+    public int speed;
+    private int correctAnswers;
+    private int wrongAnswers;
     public Button trueOption, falseOption, skipOption;
-    public TextView questionView, timer, scoreView;
-    public long millisLeft;
+    public TextView questionView;
+    private TextView timer;
+    public TextView scoreView;
+    private long millisLeft;
     public CountDownTimer countDownTimer;
     public ViewPropertyAnimator animator;
-    final String SOUND_TYPE = "SOUND_TYPE";
-    final static int BGM = 0;
+    private final String SOUND_TYPE = "SOUND_TYPE";
+    private final static int BGM = 0;
     private SharedPreferences prefs;
-    final String CURR_POSITION = "CURR_POSITION";
+    private final String CURR_POSITION = "CURR_POSITION";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -70,7 +75,7 @@ public class SinkToSwimGame extends AppCompatActivity {
     /**
      * @desc sets up the initial setting of the game
      */
-    public void initialSetUp() {
+    private void initialSetUp() {
         boolean calledByTutorialsActivity = getIntent().
                 getBooleanExtra(PowerUpUtils.CALLED_BY, false);
         if(!calledByTutorialsActivity) {
@@ -124,9 +129,9 @@ public class SinkToSwimGame extends AppCompatActivity {
     }
 
 
-    public void gameBegins() {
+    private void gameBegins() {
         //defines the wave animation on boat
-        mAnimation = AnimationUtils.loadAnimation(this, R.animator.boat_animation);
+        Animation mAnimation = AnimationUtils.loadAnimation(this, R.animator.boat_animation);
         mAnimation.setInterpolator(new LinearInterpolator());
         mAnimation.setRepeatMode(Animation.INFINITE); //does not work
         boat.startAnimation(mAnimation); //starts wave animation on boat

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimSound.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimSound.java
@@ -14,11 +14,11 @@ import powerup.systers.com.R;
  */
 
 public class SinkToSwimSound extends Service {
-    MediaPlayer mediaPlayer;
-    final String SOUND_TYPE = "SOUND_TYPE";
-    final static int BGM = 0;
+    private MediaPlayer mediaPlayer;
+    private final String SOUND_TYPE = "SOUND_TYPE";
+    private final static int BGM = 0;
     private SharedPreferences  prefs;
-    final String CURR_POSITION = "CURR_POSITION";
+    private final String CURR_POSITION = "CURR_POSITION";
 
     @Override
     public IBinder onBind(Intent intent) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimTutorials.java
@@ -12,9 +12,9 @@ import powerup.systers.com.powerup.PowerUpUtils;
 
 public class SinkToSwimTutorials extends AppCompatActivity {
 
-    ImageView tutorialView;
-    int curTutorialImage;
-    ImageView startButton;
+    private ImageView tutorialView;
+    private int curTutorialImage;
+    private ImageView startButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -31,12 +31,18 @@ import powerup.systers.com.datamodel.SessionHistory;
 public class VocabMatchGameActivity extends AppCompatActivity {
 
     public VocabBoardTextView tv1, tv2, tv3;
-    public VocabTileImageView img1, img2, img3;
-    public int height, width, oldestTile, score, latestTile;
-    public TextView scoreView;
-    public MediaPlayer mediaPlayerPlus;
-    public MediaPlayer mediaPlayerNegative;
-    Random r;
+    public VocabTileImageView img1;
+    private VocabTileImageView img2;
+    private VocabTileImageView img3;
+    private int height;
+    private int width;
+    private int oldestTile;
+    private int score;
+    public int latestTile;
+    private TextView scoreView;
+    private MediaPlayer mediaPlayerPlus;
+    private MediaPlayer mediaPlayerNegative;
+    private Random r;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -70,7 +76,7 @@ public class VocabMatchGameActivity extends AppCompatActivity {
         mediaPlayerNegative = MediaPlayer.create(this, R.raw.negative_hurt);
     }
 
-    public void initialSetUp() {
+    private void initialSetUp() {
         boolean calledByTutorialsActivity = getIntent().
                 getBooleanExtra(PowerUpUtils.CALLED_BY, false);
         if(!calledByTutorialsActivity) {
@@ -201,7 +207,7 @@ public class VocabMatchGameActivity extends AppCompatActivity {
             return tv3;
     }
 
-    View.OnDragListener listenDrag = new View.OnDragListener() {
+    private View.OnDragListener listenDrag = new View.OnDragListener() {
 
         @Override
         public boolean onDrag(View v, DragEvent event) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchSessionManager.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchSessionManager.java
@@ -10,15 +10,12 @@ import android.content.SharedPreferences;
 public class VocabMatchSessionManager {
     private final String GAME_OPENED = "IS_VOCAB_MATCH_OPENED";
     private final String PREF_NAME = "VOCAB_MATCH_PREFERENCE";
-    static final String CURR_SCORE = "currScore";
-    static final String CURR_TILE = "currTile";
+    private static final String CURR_SCORE = "currScore";
+    private static final String CURR_TILE = "currTile";
     private final int PRIVATE_MODE = 0;
-
-    SharedPreferences pref;
-    Context context;
-    SharedPreferences.Editor editor;
+    private SharedPreferences pref;
+    private SharedPreferences.Editor editor;
     public VocabMatchSessionManager(Context context) {
-        this.context = context;
         pref = context.getSharedPreferences(PREF_NAME, PRIVATE_MODE);
         editor = pref.edit();
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchTutorials.java
@@ -13,8 +13,8 @@ import powerup.systers.com.sink_to_swim_game.SinkToSwimGame;
 
 public class VocabMatchTutorials extends AppCompatActivity {
 
-    ImageView tutorialView;
-    int curTutorialImage;
+    private ImageView tutorialView;
+    private int curTutorialImage;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/MinesweeperGameTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/MinesweeperGameTests.java
@@ -42,8 +42,8 @@ import static org.junit.Assert.assertTrue;
 
 public class MinesweeperGameTests {
 
-    MinesweeperGameActivity activity;
-    MinesweeperSessionManager sessionManager;
+    private MinesweeperGameActivity activity;
+    private MinesweeperSessionManager sessionManager;
 
     // Initial setup for running Robolectric test, this function is called before starting each test
     @Before

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/ProsConsTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/ProsConsTests.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
 public class ProsConsTests {
 
-    ProsAndConsActivity activity;
+    private ProsAndConsActivity activity;
 
     @Before
     public void setUp() throws Exception {

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SinkToSwimTests.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
 public class SinkToSwimTests {
 
-    SinkToSwimGame activity;
+    private SinkToSwimGame activity;
 
     @Before
     public void setUp() throws Exception {

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/VocabMatchTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/VocabMatchTests.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertNotNull;
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
 public class VocabMatchTests {
 
-    VocabMatchGameActivity activity;
+    private VocabMatchGameActivity activity;
 
     @Before
     public void setUp() throws Exception {


### PR DESCRIPTION
### Description
Under the declaration redundancy warnings, there were warnings required to change default private levels and properties which need to be private access modifier.
This warnings were related to 25 java classes. I declared them using private access modifier to required methods and variables which are already declared using default.

Fixes #703 

### Type of Change:

- Code

### How Has This Been Tested?
I Inspected the code. After doing changes it did not show the previous warnings. And I compiled the project and run it on the device after doing changes.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
