### PR TITLE
Fixes #1069 Selected items are displayed on Avatar

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StoreActivity.java
@@ -212,6 +212,52 @@ public class StoreActivity extends AppCompatActivity {
         }
     }
 
+    public void trySelectedStoreItem(int index, int accessoryType) {
+        switch (accessoryType){
+            case PowerUpUtils.TYPE_HAIR:
+                String hairImageName = getResources().getString(R.string.hair);
+                hairImageName = hairImageName + index;
+                try {
+                    photoNameField = ourRID.getClass().getField(hairImageName);
+                    hairImageView.setImageResource(photoNameField.getInt(ourRID));
+                } catch (NoSuchFieldException | IllegalAccessException
+                        | IllegalArgumentException error) {
+                    error.printStackTrace();
+                }
+                break;
+            case PowerUpUtils.TYPE_CLOTHES:
+                String clothImageName = getResources().getString(R.string.cloth);
+                clothImageName = clothImageName + index;
+                try {
+                    photoNameField = ourRID.getClass().getField(clothImageName);
+                    clothImageView.setImageResource(photoNameField.getInt(ourRID));
+                } catch (NoSuchFieldException | IllegalAccessException
+                        | IllegalArgumentException error) {
+                    error.printStackTrace();
+                }
+                break;
+            case PowerUpUtils.TYPE_ACCESSORIES:
+                String accessoryImageName = getResources().getString(R.string.accessories);
+                accessoryImageName = accessoryImageName + index;
+                try {
+                    photoNameField = ourRID.getClass().getField(accessoryImageName);
+                    accessoryImageView.setImageResource(photoNameField.getInt(ourRID));
+                } catch (NoSuchFieldException | IllegalAccessException
+                        | IllegalArgumentException error) {
+                    error.printStackTrace();
+                }
+                break;
+        }
+    }
+
+    public void resetAvatarAccessory(){
+        try {
+            accessoryImageView.setImageResource(0);
+        } catch ( IllegalArgumentException error) {
+            error.printStackTrace();
+        }
+    }
+
     public void createDataLists() {
         allDataSet = new ArrayList<>();
 
@@ -309,27 +355,27 @@ public class StoreActivity extends AppCompatActivity {
                         TextView itemPoints = (TextView) v.findViewById(R.id.item_points);
                         int index = calculatePosition(position)+1;
                         if (storeItemTypeindex == 0) { //hair
-                            setAvatarHair(index);
                             if (getmDbHandler().getPurchasedHair(index) == 0){
                                 final int cost = Integer.parseInt(itemPoints.getText().toString());
+                                trySelectedStoreItem(index, storeItemTypeindex);
                                 showConfirmPurchaseDialog(cost, index);
                             } else {
                                 setAvatarHair(index);
                             }
 
                         } else if (storeItemTypeindex == 1) { //clothes
-                            setAvatarClothes(index);
                             if (getmDbHandler().getPurchasedClothes(index) == 0){
                                 final int cost = Integer.parseInt(itemPoints.getText().toString());
+                                trySelectedStoreItem(index, storeItemTypeindex);
                                 showConfirmPurchaseDialog(cost, index);
                             } else {
                                 setAvatarClothes(index);
                             }
 
                         } else if (storeItemTypeindex == 2) { //accessories
-                            setAvatarAccessories(index);
                             if (getmDbHandler().getPurchasedAccessories(index) == 0){
                                 final int cost = Integer.parseInt(itemPoints.getText().toString());
+                                trySelectedStoreItem(index, storeItemTypeindex);
                                 showConfirmPurchaseDialog(cost, index);
                             } else {
                                 setAvatarAccessories(index);
@@ -377,7 +423,7 @@ public class StoreActivity extends AppCompatActivity {
                 return getmDbHandler().getAvatarHair();
             case 1: //cloth
                 return getmDbHandler().getAvatarCloth();
-            case 2:
+            case 2: //accessory
                 return getmDbHandler().getAvatarAccessory();
             default:
                 throw new IllegalArgumentException("Invalid store type index");
@@ -403,13 +449,32 @@ public class StoreActivity extends AppCompatActivity {
                         break;
                     case PowerUpUtils.TYPE_ACCESSORIES:
                         getmDbHandler().setPurchasedAccessories(index);
+                        SessionHistory.accessoryBought = true;
                         setAvatarAccessories(index);
                 }
                 adapter.refresh(adapter.storeItems); // will update change the background if any is not available
                 showSuccessPurchaseDialog();
             }
         });
-        builder.setNegativeButton(R.string.purchase_confirm_cancel, null);
+        builder.setNegativeButton(R.string.purchase_confirm_cancel, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                switch (storeItemTypeindex) {
+                    case PowerUpUtils.TYPE_HAIR:
+                        trySelectedStoreItem(getmDbHandler().getAvatarHair(), PowerUpUtils.TYPE_HAIR);
+                        break;
+                    case PowerUpUtils.TYPE_CLOTHES:
+                        trySelectedStoreItem(getmDbHandler().getAvatarHair(), PowerUpUtils.TYPE_CLOTHES);
+                        break;
+                    case PowerUpUtils.TYPE_ACCESSORIES:
+                        if(SessionHistory.accessoryBought)
+                            trySelectedStoreItem(getmDbHandler().getAvatarHair(), PowerUpUtils.TYPE_ACCESSORIES);
+                        else
+                            resetAvatarAccessory();
+                        break;
+                }
+            }
+        });
         AlertDialog dialog = builder.create();
         ColorDrawable drawable = new ColorDrawable(Color.WHITE);
         drawable.setAlpha(200);

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/SessionHistory.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/SessionHistory.java
@@ -19,4 +19,5 @@ public class SessionHistory {
     public static int hatTotalNo = 4;
     public static int necklaceTotalNo = 4;
     public static int accessoryTotalNo = 4;
+    public static boolean accessoryBought = false;
 }


### PR DESCRIPTION
### Description
New functions:
```trySelectedStoreItem()```
```resetAvatarAccessory()```
are defined such that the user's selected options appear on the avatar without the selected values being wriiten on the database. If the user chooses not to buy the item, previous selected item reappears on the avatar.
The main purpose of ```resetAvatarAccessory()``` is to remove accessory from Avatar until no accessory is bought.

Fixes #1069 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
![videotogif_2018 05 04_00 23 45](https://user-images.githubusercontent.com/26908195/39597756-09fb4ad4-4f34-11e8-9ff0-21aa6a11e746.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
