### PR TITLE
Fixes #777 Handle VocabMatch when Back/Home button is pressed

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -268,7 +268,6 @@ public class VocabMatchGameActivity extends AppCompatActivity {
 
     @Override
     public void onPause() {
-        Log.e("VocanMatchGameActivity","OnPause is called");
         VocabMatchSessionManager session = new VocabMatchSessionManager(this);
         session.saveData(score, oldestTile);
         super.onPause();

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -12,9 +12,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.DragEvent;
 
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.animation.LinearInterpolator;
@@ -287,5 +287,26 @@ public class VocabMatchGameActivity extends AppCompatActivity {
         finish();
 
     }
+
+    @Override
+    protected void onStop() {
+        isBackPressed = TRUE;
+        mediaPlayerNegative.stop();
+        mediaPlayerPlus.stop();
+        super.onStop();
+    }
+
+    /* @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if ((keyCode == KeyEvent.KEYCODE_HOME)) {
+
+            isBackPressed = TRUE;
+            mediaPlayerPlus.stop();
+            mediaPlayerNegative.stop();
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
+
+    } */
 
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -12,7 +12,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.DragEvent;
+
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.animation.LinearInterpolator;
@@ -25,6 +27,9 @@ import powerup.systers.com.R;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.powerup.PowerUpUtils;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 public class VocabMatchGameActivity extends AppCompatActivity {
 
     public VocabBoardTextView tv1, tv2, tv3;
@@ -33,6 +38,7 @@ public class VocabMatchGameActivity extends AppCompatActivity {
     public TextView scoreView;
     public MediaPlayer mediaPlayerPlus;
     public MediaPlayer mediaPlayerNegative;
+    private boolean isBackPressed = FALSE;
     Random r;
 
     @Override
@@ -115,6 +121,10 @@ public class VocabMatchGameActivity extends AppCompatActivity {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     public void startNewTile(final int position, final VocabTileImageView imageview) {
+        //if back button is pressed return from function
+        if(isBackPressed == TRUE){
+            return;
+        }
 
         if (latestTile < PowerUpUtils.VOCAB_TILES_IMAGES.length) {
             imageview.setImageDrawable(getResources().getDrawable(PowerUpUtils.VOCAB_TILES_IMAGES[latestTile]));
@@ -131,6 +141,10 @@ public class VocabMatchGameActivity extends AppCompatActivity {
 
             @Override
             public void onAnimationEnd(Animator animation) {
+                //if Back button is presed return from function
+                if(isBackPressed == TRUE){
+                    return;
+                }
 
                 imageview.setLayerType(View.LAYER_TYPE_NONE, null);
                 imageview.setVisibility(View.GONE);
@@ -163,6 +177,8 @@ public class VocabMatchGameActivity extends AppCompatActivity {
                     getPositionFromText(PowerUpUtils.VOCAB_MATCHES_BOARDS_TEXTS[oldestTile]).setText(PowerUpUtils.VOCAB_MATCHES_BOARDS_TEXTS[latestTile]);
                 }
                 oldestTile++;
+
+
                 if (latestTile < PowerUpUtils.VOCAB_TILES_IMAGES.length) {
                     startNewTile(Math.abs(r.nextInt() % 3), imageview);
                 } else if (latestTile == PowerUpUtils.VOCAB_TILES_IMAGES.length + 2){
@@ -178,8 +194,9 @@ public class VocabMatchGameActivity extends AppCompatActivity {
             }
         });
         animation.start();
-    }
 
+
+    }
     public TextView getBoardFromPosition(int position) {
         if (tv1.getPosition() == position)
             return tv1;
@@ -248,8 +265,10 @@ public class VocabMatchGameActivity extends AppCompatActivity {
         }
     }
 
+
     @Override
     public void onPause() {
+        Log.e("VocanMatchGameActivity","OnPause is called");
         VocabMatchSessionManager session = new VocabMatchSessionManager(this);
         session.saveData(score, oldestTile);
         super.onPause();
@@ -262,7 +281,12 @@ public class VocabMatchGameActivity extends AppCompatActivity {
     public void onBackPressed(){
         // The flag FLAG_ACTIVITY_CLEAR_TOP checks if an instance of the activity is present and it
         // clears the activities that were created after the found instance of the required activity
+        mediaPlayerNegative.stop();
+        mediaPlayerPlus.stop();
+        isBackPressed = TRUE;
         startActivity(new Intent(VocabMatchGameActivity.this, MapActivity.class).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
         finish();
+
     }
+
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -13,8 +13,6 @@ import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 import android.util.DisplayMetrics;
 import android.view.DragEvent;
-
-import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.animation.LinearInterpolator;
@@ -121,7 +119,7 @@ public class VocabMatchGameActivity extends AppCompatActivity {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     public void startNewTile(final int position, final VocabTileImageView imageview) {
-        //if back button is pressed return from function
+        //if back button or home button is pressed return from function
         if(isBackPressed == TRUE){
             return;
         }
@@ -141,7 +139,7 @@ public class VocabMatchGameActivity extends AppCompatActivity {
 
             @Override
             public void onAnimationEnd(Animator animation) {
-                //if Back button is presed return from function
+                //if Back button or Home button is pressed return from function
                 if(isBackPressed == TRUE){
                     return;
                 }
@@ -290,23 +288,12 @@ public class VocabMatchGameActivity extends AppCompatActivity {
 
     @Override
     protected void onStop() {
+        //to handle when Home button is pressed
         isBackPressed = TRUE;
         mediaPlayerNegative.stop();
         mediaPlayerPlus.stop();
         super.onStop();
     }
 
-    /* @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if ((keyCode == KeyEvent.KEYCODE_HOME)) {
-
-            isBackPressed = TRUE;
-            mediaPlayerPlus.stop();
-            mediaPlayerNegative.stop();
-            return true;
-        }
-        return super.onKeyDown(keyCode, event);
-
-    } */
 
 }


### PR DESCRIPTION
### Description

Fixes #777

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
This has been successfully tested on an Android Device : 
 - On pressing Back/Home button, no sound is audible.
 - VocabMatchEndActivity is not displayed after pressing Back/Home.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been published in downstream modules
