### PR TITLE
Handle interruptions in mini games-bugFix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
  components:
     - platform-tools
     - tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-27.0.3
+    - android-27
 before_script:
  - chmod +x generate-apk.sh
  - cd PowerUp

--- a/PowerUp/app/build.gradle
+++ b/PowerUp/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "powerup.systers.com.powerup"
@@ -22,6 +21,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildToolsVersion '27.0.3'
 }
 
 dependencies {

--- a/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/AvatarRoomActivity.java
@@ -277,6 +277,7 @@ public class AvatarRoomActivity extends Activity {
                 getmDbHandler().setPurchasedClothes(cloth);
                 getmDbHandler().updateComplete();//set all the complete fields back to 0
                 getmDbHandler().updateReplayed();//set all the replayed fields back to 0
+                getmDbHandler().updateLock(); //set all scenarios back to locked
                 SessionHistory.totalPoints = 0;    //reset the points stored
                 SessionHistory.currSessionID = 1;
                 SessionHistory.currScenePoints = 0;

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -209,6 +209,7 @@ public class GameActivity extends Activity {
                             }
                             updatePoints(position);
                             getmDbHandler().setCompletedScenario(scene.getId());
+                            getmDbHandler().setUnlockedScenario(scene.getNextScenarioID());
                             updateScenario(0);
                         }
                     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameOverActivity.java
@@ -13,6 +13,7 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import powerup.systers.com.datamodel.SessionHistory;
+import powerup.systers.com.db.DatabaseHandler;
 
 public class GameOverActivity extends Activity {
 
@@ -27,6 +28,14 @@ public class GameOverActivity extends Activity {
         backToMap.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                //once the whole game has been completed, user should be
+                // able to play any scenario
+                if(!SessionHistory.hasGameAlreadyPlayedOnce){
+                     DatabaseHandler dbHandler = new DatabaseHandler(GameOverActivity.this); dbHandler.updateReplayed();
+                     dbHandler.updateComplete();
+                     dbHandler.updateUnlockEveryScenario();
+                     SessionHistory.hasGameAlreadyPlayedOnce = true;
+                }
                 Intent intent = new Intent(GameOverActivity.this,
                         MapActivity.class);
                 finish();

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -118,15 +118,15 @@ public class MapActivity extends Activity {
         });
 
         //changes the Map building's greyscale color and locks according to the scenarios completions
-        if (getmDbHandler().getScenarioFromID(4).getCompleted() == 1 || SessionHistory.sceneHomeIsReplayed){
+        if (getmDbHandler().getScenarioFromID(5).getUnlocked() == 1 || SessionHistory.sceneHomeIsReplayed){
             schoolBuilding.setImageDrawable(getResources().getDrawable(R.drawable.school_colored));
             school.setEnabled(true);
         }
-        if (getmDbHandler().getScenarioFromID(5).getCompleted() == 1 || SessionHistory.sceneSchoolIsReplayed){
+        if (getmDbHandler().getScenarioFromID(6).getUnlocked() == 1|| SessionHistory.sceneSchoolIsReplayed){
             hospitalBuilding.setImageDrawable(getResources().getDrawable(R.drawable.hospital_colored));
             hospital.setEnabled(true);
         }
-        if (getmDbHandler().getScenarioFromID(6).getCompleted() == 1 || SessionHistory.sceneHospitalIsReplayed){
+        if (getmDbHandler().getScenarioFromID(7).getUnlocked() == 1 || SessionHistory.sceneHospitalIsReplayed){
             libraryBuilding.setImageDrawable(getResources().getDrawable(R.drawable.library_colored));
             library.setEnabled(true);
         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Scenario.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/Scenario.java
@@ -16,6 +16,7 @@ public class Scenario {
     private int completed;  // If equal to 1, the scenario is already completed
     private int nextScenarioID;
     private int replayed;   // If equal to 0, the scenario can be replayed
+    private int unlockedScenario; // If equal to 1, Scenario gets unlocked (default is 0)
 
     public int getId() {
         return id;
@@ -88,4 +89,8 @@ public class Scenario {
     public void setReplayed(int replayed) {
         this.replayed = replayed;
     }
+
+    public void setUnlockScenario(int unlock){this.unlockedScenario = unlock;}
+
+    public int getUnlocked(){return unlockedScenario;}
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/datamodel/SessionHistory.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/datamodel/SessionHistory.java
@@ -24,4 +24,5 @@ public class SessionHistory {
     public static boolean sceneHospitalIsReplayed = false;
     public static boolean sceneLibraryIsReplayed = false;
     public static boolean hasPreviouslyCustomized = false;
+    public static boolean hasGameAlreadyPlayedOnce = false;
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/db/AbstractDbAdapter.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/db/AbstractDbAdapter.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 
 public abstract class AbstractDbAdapter {
 
-    private static final int DATABASE_VERSION = 2;
+    private static final int DATABASE_VERSION = 3;
     private static final String DATABASE_NAME = "PowerUpDB";
     protected static SQLiteDatabase mDb;
     private static BufferedReader in;
@@ -142,6 +142,7 @@ public abstract class AbstractDbAdapter {
                 values.put(PowerUpContract.ScenarioEntry.COLUMN_COMPLETED, 0);
                 values.put(PowerUpContract.ScenarioEntry.COLUMN_NEXT_SCENARIO_ID, rowData[6]);
                 values.put(PowerUpContract.ScenarioEntry.COLUMN_REPLAYED, 0);
+                values.put(PowerUpContract.ScenarioEntry.COLUMN_UNLOCKED,0);
                 db.insert(PowerUpContract.ScenarioEntry.TABLE_NAME, null, values);
             } else {
                 throw new Error("Incorrect Scenario CSV Format! Use ID,"
@@ -330,7 +331,8 @@ public abstract class AbstractDbAdapter {
                     PowerUpContract.ScenarioEntry.COLUMN_FIRST_QUESTION_ID + " INTEGER, " +
                     PowerUpContract.ScenarioEntry.COLUMN_COMPLETED + " INTEGER, " +
                     PowerUpContract.ScenarioEntry.COLUMN_NEXT_SCENARIO_ID + " INTEGER, " +
-                    PowerUpContract.ScenarioEntry.COLUMN_REPLAYED + " INTEGER" +
+                    PowerUpContract.ScenarioEntry.COLUMN_REPLAYED + " INTEGER, " +
+                    PowerUpContract.ScenarioEntry.COLUMN_UNLOCKED + " INTEGER" +
                     ")";
 
             String CREATE_POINT_TABLE = "CREATE TABLE " + PowerUpContract.PointEntry.TABLE_NAME + "(" +

--- a/PowerUp/app/src/main/java/powerup/systers/com/db/DatabaseHandler.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/db/DatabaseHandler.java
@@ -89,6 +89,7 @@ public class DatabaseHandler extends AbstractDbAdapter {
             scene.setCompleted(cursor.getInt(6));
             scene.setNextScenarioID(cursor.getInt(7));
             scene.setReplayed(cursor.getInt(8));
+            scene.setUnlockScenario(cursor.getInt(9));
             return scene;
         }
         cursor.close();
@@ -116,6 +117,7 @@ public class DatabaseHandler extends AbstractDbAdapter {
             scene.setCompleted(cursor.getInt(6));
             scene.setNextScenarioID(cursor.getInt(7));
             scene.setReplayed(cursor.getInt(8));
+            scene.setUnlockScenario(cursor.getInt(9));
             return scene;
         }
         cursor.close();
@@ -445,4 +447,44 @@ public class DatabaseHandler extends AbstractDbAdapter {
                 " WHERE " + PowerUpContract.AvatarEntry.COLUMN_ID + " = 1";
         mDb.execSQL(query);
     }
+
+    /**
+     * @desc unlocks the scenario with given scenario id
+     * @param id - the id of scenario to be unlocked
+     */
+    public void setUnlockedScenario(int id){
+               String query = "UPDATE " + PowerUpContract.ScenarioEntry.TABLE_NAME +
+                       " SET " + PowerUpContract.ScenarioEntry.COLUMN_UNLOCKED + " = 1" +
+                       " WHERE " + PowerUpContract.ScenarioEntry.COLUMN_ID + " = " + id;
+               mDb.execSQL(query);
+    }
+
+    /**
+     * @desc Locks te scenario with given scenario id
+     * @param id - the id of scenario to be locked
+     */
+     public void resetUnlocked(int id){
+         String query = "UPDATE " + PowerUpContract.ScenarioEntry.TABLE_NAME +
+                 " SET " + PowerUpContract.ScenarioEntry.COLUMN_UNLOCKED + " = 0" +
+                 " WHERE " + PowerUpContract.ScenarioEntry.COLUMN_ID + " = " + id;
+               mDb.execSQL(query);
+     }
+
+    /**
+     * @desc Locks every scenario
+     */
+     public void updateLock(){
+         String query = "UPDATE " + PowerUpContract.ScenarioEntry.TABLE_NAME +
+                 " SET " + PowerUpContract.ScenarioEntry.COLUMN_UNLOCKED + " = 0";
+         mDb.execSQL(query);
+     }
+
+    /**
+     * @desc Unlocks every scenario
+     */
+     public void updateUnlockEveryScenario(){
+             String query = "UPDATE " + PowerUpContract.ScenarioEntry.TABLE_NAME +
+                     " SET " + PowerUpContract.ScenarioEntry.COLUMN_UNLOCKED + " = 1";
+             mDb.execSQL(query);
+     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/db/PowerUpContract.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/db/PowerUpContract.java
@@ -30,6 +30,7 @@ public class PowerUpContract {
 
         public static final String COLUMN_REPLAYED = "Replayed";
 
+        public static final String COLUMN_UNLOCKED = "Unlocked";
     }
 
     public static final class AvatarEntry implements BaseColumns {

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperGameActivity.java
@@ -63,7 +63,6 @@ public class MinesweeperGameActivity extends AppCompatActivity {
         numSelectionsLeft = PowerUpUtils.MAXIMUM_FLIPS_ALLOWED;
 
         if (!calledByTutorialsActivity) { //if called by previous round of minesweeper game
-
             //fetch previous round score and rounds completed from session database
             MinesweeperSessionManager session = new MinesweeperSessionManager(this);
             score = session.getScore();

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/MinesweeperTutorials.java
@@ -8,6 +8,8 @@ import android.widget.ImageView;
 
 import powerup.systers.com.MapActivity;
 import powerup.systers.com.R;
+import powerup.systers.com.datamodel.SessionHistory;
+import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class MinesweeperTutorials extends AppCompatActivity {
@@ -18,6 +20,11 @@ public class MinesweeperTutorials extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        //Locks Hospital Scenario Only for the very first time
+        if(!SessionHistory.hasGameAlreadyPlayedOnce) {
+             DatabaseHandler dbHandler = new DatabaseHandler(this);
+             dbHandler.resetUnlocked(6);
+        }
         setContentView(R.layout.activity_minesweeper_tutorials);
         tutorialView = (ImageView) findViewById(R.id.tut);
         curTutorialImage = 1;
@@ -47,5 +54,5 @@ public class MinesweeperTutorials extends AppCompatActivity {
         startActivity(new Intent(MinesweeperTutorials.this, MapActivity.class).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
         finish();
     }
-    }
+}
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/minesweeper/ProsAndConsActivity.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 import powerup.systers.com.MapActivity;
 import powerup.systers.com.R;
 import powerup.systers.com.ScenarioOverActivity;
+import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class ProsAndConsActivity extends AppCompatActivity {
@@ -20,6 +21,8 @@ public class ProsAndConsActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        DatabaseHandler dbHandler = new DatabaseHandler(this);
+        dbHandler.setUnlockedScenario(6); //unlocks School Scenario
         setContentView(R.layout.minesweeper_pros_cons);
         proOne = (TextView) findViewById(R.id.pro_one);
         proTwo = (TextView) findViewById(R.id.pro_two);
@@ -45,7 +48,7 @@ public class ProsAndConsActivity extends AppCompatActivity {
             startActivity(new Intent(ProsAndConsActivity.this, MinesweeperGameActivity.class).putExtra(PowerUpUtils.CALLED_BY, false));
             overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
         } else {
-            new MinesweeperSessionManager(this).saveMinesweeperOpenedStatus(false); //marks minesweeper game as finished
+            new MinesweeperSessionManager(this).saveMinesweeperOpenedStatus(false);//marks minesweeper game as finished
             Intent intent = new Intent(ProsAndConsActivity.this, ScenarioOverActivity.class);
             intent.putExtra(String.valueOf(R.string.scene), PowerUpUtils.MINESWEEP_PREVIOUS_SCENARIO);
             startActivity(intent);

--- a/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/sink_to_swim_game/SinkToSwimTutorials.java
@@ -8,6 +8,7 @@ import android.widget.ImageView;
 
 import powerup.systers.com.MapActivity;
 import powerup.systers.com.R;
+import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class SinkToSwimTutorials extends AppCompatActivity {
@@ -19,6 +20,7 @@ public class SinkToSwimTutorials extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        new DatabaseHandler(this).setUnlockedScenario(7);
         setContentView(R.layout.activity_sink_to_swim_tutorials);
         tutorialView = (ImageView) findViewById(R.id.tut);
         startButton = (ImageView) findViewById(R.id.start_button);

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchEndActivity.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 import powerup.systers.com.MapActivity;
 import powerup.systers.com.R;
 import powerup.systers.com.ScenarioOverActivity;
+import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class VocabMatchEndActivity extends AppCompatActivity {
@@ -33,6 +34,8 @@ public class VocabMatchEndActivity extends AppCompatActivity {
 
     public void continuePressed(View view){
         VocabMatchSessionManager session = new VocabMatchSessionManager(this);
+        DatabaseHandler dbHandler = new DatabaseHandler(this);
+        dbHandler.setUnlockedScenario(7); //unlocks Libary scenario
         Intent intent = new Intent(VocabMatchEndActivity.this, ScenarioOverActivity.class);
         session.saveVocabMatchOpenedStatus(false);
         finish();

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchGameActivity.java
@@ -33,6 +33,7 @@ public class VocabMatchGameActivity extends AppCompatActivity {
     public TextView scoreView;
     public MediaPlayer mediaPlayerPlus;
     public MediaPlayer mediaPlayerNegative;
+    private boolean isDisrupted = false;
     Random r;
 
     @Override
@@ -115,7 +116,9 @@ public class VocabMatchGameActivity extends AppCompatActivity {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     public void startNewTile(final int position, final VocabTileImageView imageview) {
-
+        //if Back/Home is pressed, return from function
+        if(isDisrupted)
+            return;
         if (latestTile < PowerUpUtils.VOCAB_TILES_IMAGES.length) {
             imageview.setImageDrawable(getResources().getDrawable(PowerUpUtils.VOCAB_TILES_IMAGES[latestTile]));
         }
@@ -131,7 +134,10 @@ public class VocabMatchGameActivity extends AppCompatActivity {
 
             @Override
             public void onAnimationEnd(Animator animation) {
-
+                //if Home/Back is pressed ,return from function so that already executing function
+                //calls of startNewTile do not execute this function.
+                if(isDisrupted)
+                    return;
                 imageview.setLayerType(View.LAYER_TYPE_NONE, null);
                 imageview.setVisibility(View.GONE);
                 final TextView boardView = getBoardFromPosition(imageview.getPosition());
@@ -262,7 +268,19 @@ public class VocabMatchGameActivity extends AppCompatActivity {
     public void onBackPressed(){
         // The flag FLAG_ACTIVITY_CLEAR_TOP checks if an instance of the activity is present and it
         // clears the activities that were created after the found instance of the required activity
+        isDisrupted = true;
+        mediaPlayerPlus.stop();
+        mediaPlayerNegative.stop();
         startActivity(new Intent(VocabMatchGameActivity.this, MapActivity.class).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
         finish();
+    }
+
+    //to handle issues when Home button is pressed
+    @Override
+    protected void onStop() {
+        isDisrupted = true;
+        mediaPlayerNegative.stop();
+        mediaPlayerPlus.stop();
+        super.onStop();
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabMatchTutorials.java
@@ -8,6 +8,8 @@ import android.widget.ImageView;
 
 import powerup.systers.com.MapActivity;
 import powerup.systers.com.R;
+import powerup.systers.com.datamodel.SessionHistory;
+import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class VocabMatchTutorials extends AppCompatActivity {
@@ -18,6 +20,11 @@ public class VocabMatchTutorials extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        //locks Library Scenario (only for the very first time)
+        if(!SessionHistory.hasGameAlreadyPlayedOnce) {
+            DatabaseHandler dbHandler = new DatabaseHandler(this);
+            dbHandler.resetUnlocked(7);
+        }
         setContentView(R.layout.activity_vocab_match_tutorials);
         tutorialView = (ImageView) findViewById(R.id.tut);
         curTutorialImage = 1;

--- a/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabTileImageView.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/vocab_match_game/VocabTileImageView.java
@@ -15,7 +15,6 @@ public class VocabTileImageView extends android.support.v7.widget.AppCompatImage
         super(context, attrs);
     }
 
-
     public int getPosition() {
         return position;
     }

--- a/PowerUp/build.gradle
+++ b/PowerUp/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -22,9 +22,9 @@ allprojects {
 ext {
     // Sdk and tools
     minSdkVersion = 15
-    targetSdkVersion = 26
-    compileSdkVersion = 26
-    buildToolsVersion = '26.0.2'
+    targetSdkVersion = 27
+    compileSdkVersion = 27
+    buildToolsVersion = '27.0.3'
 
     // App dependencies
     supportLibraryVersion = '26.1.0'

--- a/PowerUp/gradle.properties
+++ b/PowerUp/gradle.properties
@@ -16,5 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.enableAapt2=false
+
 

--- a/PowerUp/gradle/wrapper/gradle-wrapper.properties
+++ b/PowerUp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 15 22:17:24 IST 2018
+#Tue Jun 05 10:21:51 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
### Description
Handles interruptions in mini games 
1. Keeps next scenario unlocked if back is pressed while playing.
2. Stop background music if back is pressed.

BONUS : After all the scenarios are completed - clicking on any scenario opened only the Library one, but now clicking on any scenario opens the respective scenario.

Fixes #777


### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
It has been run successfully on an android device.
![20180604_234433](https://user-images.githubusercontent.com/24635221/40934491-968ae02c-6852-11e8-9b87-3e2bc121a447.gif)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] New and existing unit tests pass locally with my changes

