### PR TITLE
Added layout for main screen of memory match

### DIFF
--- a/PowerUp/app/src/main/res/layout-land/activity_memory_match_game.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_memory_match_game.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/vocab_bg">
+
+
+        <ImageView
+            android:id="@+id/img_tile_2"
+            android:layout_width="@dimen/memory_tile_size"
+            android:layout_height="@dimen/memory_tile_size"
+            android:src="@drawable/yellow_star"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.55" />
+
+        <ImageView
+            android:id="@+id/img_tile_3"
+            android:layout_width="@dimen/memory_tile_size"
+            android:layout_height="@dimen/memory_tile_size"
+            android:src="@drawable/yellow_star"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.55" />
+
+        <ImageView
+            android:id="@+id/img_tile_1"
+            android:layout_width="@dimen/memory_tile_size"
+            android:layout_height="@dimen/memory_tile_size"
+            android:src="@drawable/yellow_star"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.9"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.55" />
+
+        <ImageView
+            android:id="@+id/img_score"
+            android:layout_width="@dimen/score_label_size"
+            android:layout_height="@dimen/score_label_size"
+            android:src="@drawable/vocab_score"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/txt_score"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/txt_zero"
+            android:textColor="@color/powerup_dark_blue"
+            android:textSize="@dimen/txt_size_large"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@+id/img_score"
+            app:layout_constraintEnd_toEndOf="@+id/img_score"
+            app:layout_constraintHorizontal_bias="0.30"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.6" />
+
+        <TextView
+            android:id="@+id/txt_time_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_large"
+            android:text="@string/time"
+            android:textColor="@color/powerup_dark_blue"
+            android:textSize="@dimen/txt_size"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@+id/txt_time"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/txt_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_large"
+            android:layout_marginTop="@dimen/margin_large"
+            android:text="@string/txt_zero"
+           android:textColor="@color/powerup_dark_blue"
+            android:textSize="@dimen/txt_size"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/txt_label_memory"
+            android:layout_width="@dimen/memory_label_width"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_small"
+            android:layout_marginStart="@dimen/margin_small"
+            android:layout_marginTop="@dimen/margin_large"
+            android:text="@string/memory_label"
+            android:textColor="@color/powerup_dark_blue"
+            android:textSize="@dimen/txt_size_large"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@+id/txt_time_label"
+           app:layout_constraintStart_toEndOf="@+id/img_score"
+           app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/btn_yes"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/btn_margin_bottom"
+            android:background="@drawable/btn_bg"
+            android:text="@string/yes"
+            android:textColor="@color/powerup_dark_blue"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/img_tile_2" />
+
+        <Button
+            android:id="@+id/btn_no"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/btn_margin_bottom"
+            android:background="@drawable/btn_bg"
+            android:text="@string/no"
+            android:textColor="@color/powerup_dark_blue"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/img_tile_2" />
+
+    <ImageView
+        android:id="@+id/btn_start"
+        android:layout_width="@dimen/start_width_memory"
+        android:layout_height="@dimen/start_height_memory"
+        android:layout_marginBottom="@dimen/margin_large"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:src="@drawable/start_button" />
+
+    </android.support.constraint.ConstraintLayout>

--- a/PowerUp/app/src/main/res/values-land/dimens.xml
+++ b/PowerUp/app/src/main/res/values-land/dimens.xml
@@ -264,4 +264,6 @@
     <dimen name="spacing_grid_view">10dp</dimen>
     <dimen name="size_npc">100dp</dimen>
     <dimen name="left_margin_arrow">24dp</dimen>
+    <dimen name="start_width_memory">130dp</dimen>
+    <dimen name="start_height_memory">70dp</dimen>
 </resources>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -35,5 +35,8 @@
     <dimen name="score_text_size_large">45sp</dimen>
     <dimen name="continue_width">220dp</dimen>
     <dimen name="continue_height">95dp</dimen>
+    <dimen name="memory_tile_size">120dp</dimen>
+    <dimen name="memory_label_width">401dp</dimen>
+    <dimen name="btn_margin_bottom">24dp</dimen>
 </resources>
 

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -105,4 +105,7 @@
     <string name="pregame_warning_message">To proceed in the game you need to choose atleast one character</string>
     <string name="time">Time: </string>
     <string name="txt_zero">00</string>
+    <string name="memory_label">Does the tile on the left match the tile that appeared one tile before it?</string>
+    <string name="no">NO</string>
+    <string name="yes">YES</string>
 </resources>


### PR DESCRIPTION
### Description
Assws xml layout for main screen of mini game 2 - Memory Match.
The laoyout is designed according to the mocks shared earlier

Fixes #1188 

### Type of Change:

- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Currently there is not any code to launch the screen.
I have modified code to check it on my device.

![35540112_1658190420965929_2757934818728607744_n](https://user-images.githubusercontent.com/26908195/41590410-8e2c6602-73d4-11e8-9ff6-911421c15b11.png)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
