### PR TITLE
Added end screen for memory match

### DIFF
--- a/PowerUp/app/src/main/res/layout-land/activity_memory_match_end.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_memory_match_end.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/swim_game_end">
+
+    <TextView
+        android:id="@+id/txt_memory_score"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_zero"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/memory_score_txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.08"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.65" />
+
+    <TextView
+        android:id="@+id/txt_memory_correct"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_zero"
+        android:textColor="@color/correct_answer"
+        android:textSize="@dimen/memory_score_txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.65" />
+
+    <TextView
+        android:id="@+id/textView4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_zero"
+        android:textColor="@color/cons_text"
+        android:textSize="@dimen/memory_score_txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.85"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.65" />
+
+    <ImageView
+        android:id="@+id/continue_btn_memory"
+        android:layout_width="@dimen/continue_height_memory"
+        android:layout_height="@dimen/continue_width_memory"
+        android:src="@drawable/continue_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -35,5 +35,8 @@
     <dimen name="score_text_size_large">45sp</dimen>
     <dimen name="continue_width">220dp</dimen>
     <dimen name="continue_height">95dp</dimen>
+    <dimen name="memory_score_txt_size">40sp</dimen>
+    <dimen name="continue_width_memory">100dp</dimen>
+    <dimen name="continue_height_memory">230dp</dimen>
 </resources>
 


### PR DESCRIPTION
### Description
I have added the game end screen for mini game 2 - Memory Match.
The screen contains 3 text views toshow total points scored, number of correct answers and number of wrong answers.

Fixes #1189 

### Type of Change:

- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

![35922879_1659535490831422_30619689436577792_n](https://user-images.githubusercontent.com/26908195/41644678-6528ff00-748c-11e8-9a7f-260e97d0eb4b.png)

### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
