### PR TITLE
Add tutorials for kill the virus

### DIFF
--- a/PowerUp/app/src/main/res/drawable/btn_bg.xml
+++ b/PowerUp/app/src/main/res/drawable/btn_bg.xml
@@ -2,7 +2,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
 
-    <solid android:color="@color/about_background"/>
+    <solid android:color="#ffffff"/>
 
     <stroke
         android:width="5dp"

--- a/PowerUp/app/src/main/res/layout-land/activity_kill_the_virus_tutorial.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_kill_the_virus_tutorial.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <include layout="@layout/activity_kill_the_virus_game" />
+
+            <TextView
+                android:id="@+id/txt_tutorial_1"
+                android:layout_width="@dimen/tutorial_1_width"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_small"
+                android:layout_marginStart="@dimen/margin_small"
+                android:background="@drawable/btn_bg"
+                android:padding="@dimen/margin_small"
+                android:text="@string/tutorial_1"
+                android:textColor="@color/powerup_dark_blue"
+                android:textSize="@dimen/tutorial_text_size"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/txt_tutorial_2"
+                android:layout_width="@dimen/tutorial_2_width"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:layout_marginEnd="@dimen/margin_small"
+                android:background="@drawable/btn_bg"
+                android:padding="@dimen/margin_small"
+                android:text="@string/tutorial_2"
+                android:textColor="@color/powerup_dark_blue"
+                android:textSize="@dimen/tutorial_text_size"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <TextView
+                android:id="@+id/txt_tutorial_3"
+                android:layout_width="@dimen/tutorial_3_width"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_small"
+                android:layout_marginEnd="@dimen/tutorial_3_margin"
+                android:layout_marginTop="@dimen/margin_small"
+                android:background="@drawable/btn_bg"
+                android:padding="@dimen/margin_small"
+                android:text="@string/tutorial_3"
+                android:textColor="@color/powerup_dark_blue"
+                android:textSize="@dimen/tutorial_text_size"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.19" />
+
+        </android.support.constraint.ConstraintLayout>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -38,5 +38,10 @@
     <dimen name="memory_tile_size">120dp</dimen>
     <dimen name="memory_label_width">401dp</dimen>
     <dimen name="btn_margin_bottom">24dp</dimen>
+    <dimen name="tutorial_text_size">22sp</dimen>
+    <dimen name="tutorial_1_width">150dp</dimen>
+    <dimen name="tutorial_2_width">255dp</dimen>
+    <dimen name="tutorial_3_width">265dp</dimen>
+    <dimen name="tutorial_3_margin">32dp</dimen>
 </resources>
 

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -108,4 +108,7 @@
     <string name="memory_label">Does the tile on the left match the tile that appeared one tile before it?</string>
     <string name="no">NO</string>
     <string name="yes">YES</string>
+    <string name="tutorial_1">Shoot the viruses with the syringe!</string>
+    <string name="tutorial_2">The color of the syringe should match with the color of the virus otherwise you loose!</string>
+    <string name="tutorial_3">Try to kill as many viruses as possible before the time runs out!</string>
 </resources>


### PR DESCRIPTION
### Description

I have added xml layout for the tutorial of the mini game.
It contains three text views, viz. , txt_tutorial_1, txt_tutorial_2, txt_tutorial_3 to give proper instructions to the user before starting the game.
I have used <include/> tag to have a proper background of mini game, that adapts properly to the screen,  when the textviews are shown. 
The logic I am planning to use here is change the value android:alpha to change the visibility of the design elements according to the tutorials that I will implement during coding.
Fixes #1179 

Note: This is a rectification PR for #1180. I somehow deleted the commit while resolving the conflicts and was not able to push the commits so I made a new PR.

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

This is current xml view of the tutorial
![kill_tut](https://user-images.githubusercontent.com/26908195/41496993-0f2a95e8-716a-11e8-888f-6109398a419a.png)

The screens would be eventually modified like this:

![screenshot_2018-06-16-12-48-09-318_powerup systers com powerup](https://user-images.githubusercontent.com/26908195/41497004-2fcc4c88-716a-11e8-80e2-456a8fed51b3.png)

![screenshot_2018-06-16-12-45-41-119_powerup systers com powerup](https://user-images.githubusercontent.com/26908195/41497006-32792d3e-716a-11e8-9a16-7bbd27c4cd34.png)

![screenshot_2018-06-16-12-55-14-815_powerup systers com powerup](https://user-images.githubusercontent.com/26908195/41497007-33bcfea0-716a-11e8-96bc-2e8aad01b397.png)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
