### PR TITLE
Kill the virus tutorials

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusTutorials.java
@@ -1,8 +1,10 @@
 package powerup.systers.com.kill_the_virus_game;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -30,7 +32,7 @@ public class KillTheVirusTutorials extends Activity {
     @BindView(R.id.img_virus_8)
     public ImageView imgVirus8;
     @BindView(R.id.img_syringe)
-    public ImageView imgSyringe;
+    public View imgSyringe;
     @BindView(R.id.txt_tutorial_1)
     public TextView txtTutorial1;
     @BindView(R.id.txt_tutorial_2)
@@ -46,6 +48,7 @@ public class KillTheVirusTutorials extends Activity {
     @BindView(R.id.txt_score)
     public TextView txtScore;
     public int tutorialCount = 0;
+    private final float visible = 1, notVisible = (float) 0.7, gone = 0;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -61,19 +64,46 @@ public class KillTheVirusTutorials extends Activity {
             showTutorial2();
         else if (tutorialCount == 2)
             showTutorial3();
-        //else
-        //Start the game
+        else {
+            startActivity(new Intent(KillTheVirusTutorials.this, KillTheVirusGame.class));
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+            }
     }
 
     public void initializeViews() {
-        //TODO: Initialize the visibility of the tutorials
+        imgSyringe.setAlpha(notVisible);
+        txtTutorial2.setAlpha(gone);
+        txtTutorial3.setAlpha(gone);
+        txtScore.setAlpha(notVisible);
+        imgScore.setAlpha(notVisible);
+        txtTime.setAlpha(notVisible);
+        txtTimeLabel.setAlpha(notVisible);
+        tutorialCount = 1;
     }
 
     public void showTutorial2() {
-        //TODO: Update the visibility of elements
+        imgVirus1.setAlpha(notVisible);
+        imgVirus2.setAlpha(notVisible);
+        imgVirus3.setAlpha(notVisible);
+        imgVirus4.setAlpha(notVisible);
+        imgVirus5.setAlpha(notVisible);
+        imgVirus6.setAlpha(notVisible);
+        imgVirus7.setAlpha(notVisible);
+        imgVirus8.setAlpha(notVisible);
+        imgSyringe.setAlpha(visible);
+        txtTutorial1.setAlpha(gone);
+        txtTutorial2.setAlpha(visible);
+        tutorialCount = 2;
     }
 
     public void showTutorial3() {
-        //TODO: Update the visibility of elements
+        imgSyringe.setAlpha(notVisible);
+        txtTutorial2.setAlpha(gone);
+        txtTutorial3.setAlpha(visible);
+        txtScore.setAlpha(notVisible);
+        imgScore.setAlpha(notVisible);
+        txtTime.setAlpha(visible);
+        txtTimeLabel.setAlpha(visible);
+        tutorialCount = 3;
     }
 }


### PR DESCRIPTION
### Description
I have added functionality to the tutorial screen of mini game 1 such that all the tutorials are shown in proper sequence and then the game is started.

- Create a onClickListener() on whole layout so that the screen can be updated when touched anywhere
- Declare a count variable tutorialCount = 0, to change the alpha values of the design elements to make the proper tutorials visible
- The variables visiblie, notVisible and gone are used to set the value for alpha
- When tutorialCount is 0 first tutorial screen will be visible using function initializeViews()
- When tutorialCount is 1 second tutorial screen will be visible using function showTutorial2()
- When tutorialCount is 2 third tutorial screen will be visible using function showTutorial3()
- When tutorialCount is 3 -> intent transition from tutorial screen to main screen

Fixes #1205 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Currently there is no direct option to trigger the mini game.
One way to launch it is by changing line 116 of StartActivity.java from
```  startActivity(new Intent(StartActivity.this, AboutActivity.class)); ```
to 
```  startActivity(new Intent(StartActivity.this, KillTheVirusGame.class)); ``` 
and then using ABOUT button on the main screen of app to launch the game.

![videotogif_2018 06 26_13 26 19](https://user-images.githubusercontent.com/26908195/41897789-e584c3ec-7945-11e8-8ad9-7eb09f7d17be.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
