### PR TITLE
Added functionality to end screen

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusEndActivity.java
@@ -1,6 +1,7 @@
 package powerup.systers.com.kill_the_virus_game;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.widget.TextView;
 
@@ -8,6 +9,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.R;
+import powerup.systers.com.StartActivity;
 
 public class KillTheVirusEndActivity extends Activity {
 
@@ -19,11 +21,24 @@ public class KillTheVirusEndActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_kill_the_virus_end);
         ButterKnife.bind(this);
-        //TODO: Update the score text view to display scored points
+        updateScore();
     }
 
-    @OnClick
+    @OnClick(R.id.btn_continue_memory)
     public void clickContinue() {
-        //TODO: Migrate to scene completion screen
+        startActivity(new Intent(KillTheVirusEndActivity.this, StartActivity.class));
+        overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+    }
+
+    private void updateScore() {
+        //getting the value of score from intent extra
+        int score = getIntent().getIntExtra(getString(R.string.score_kill_the_virus), -1);
+        txtScoreEnd.setText("" + score);
+    }
+
+    @Override
+    public void onBackPressed() {
+        startActivity(new Intent(KillTheVirusEndActivity.this, StartActivity.class));
+        overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusGame.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusGame.java
@@ -4,6 +4,7 @@ import android.animation.ValueAnimator;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.CountDownTimer;
@@ -54,6 +55,7 @@ public class KillTheVirusGame extends Activity {
     private int[] virusColors;
     private ValueAnimator virus1Animator, virus2Animator, virus3Animator, virus4Animator, virus5Animator, virus6Animator, virus7Animator, virus8Animator;
     private Animation translateSyringe;
+    private CountDownTimer countDownTimer;
 
     @SuppressLint("ResourceType")
     @Override
@@ -95,7 +97,7 @@ public class KillTheVirusGame extends Activity {
         virus7Animator.start();
         virus8Animator.start();
 
-        new CountDownTimer(30000, 1000) {
+        countDownTimer = new CountDownTimer(30000, 1000) {
             public void onTick(long millisUntilFinished) {
                 int seconds = (int) (millisUntilFinished / 1000);
                 txtTime.setText(String.valueOf(seconds));
@@ -170,13 +172,13 @@ public class KillTheVirusGame extends Activity {
      * @param totalScore - value of total score
      */
     private void gameEnd(int totalScore) {
-        //Update the total points
-        SharedPreferences sharedPref = this.getPreferences(Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = sharedPref.edit();
-        editor.putInt(getString(R.string.score_kill_the_virus), totalScore);
-        editor.apply();
+        countDownTimer.cancel();
+        Intent intent = new Intent(KillTheVirusGame.this, KillTheVirusEndActivity.class);
+        //Passing the final score using intent extra
+        intent.putExtra(getString(R.string.score_kill_the_virus),totalScore);
         //End the Game
-        finish();
+        startActivity(intent);
+        overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }
 
     //Attaches rotational animation to all the virus images

--- a/PowerUp/app/src/main/res/layout-land/activity_kill_the_virus_end.xml
+++ b/PowerUp/app/src/main/res/layout-land/activity_kill_the_virus_end.xml
@@ -22,11 +22,11 @@
             app:layout_constraintVertical_bias="0.6" />
 
     <ImageView
-        android:id="@+id/btn_continue"
+        android:id="@+id/btn_continue_memory"
         android:layout_width="220dp"
         android:layout_height="95dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:srcCompat="@drawable/continue_button" />
+        android:src="@drawable/continue_button" />
 
     </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
### Description
I have added proper code so that scores are displayed properly
- The score is passed between activities using intent extra
- updateScore() retrives the value from intent extra

Currently, on pressing continue and back button StartActivity is launched since the mini game is not attached to any scenarios. I will update this when the new scenarios will be added.

Fixes #1207 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Currently there is no direct option to trigger the mini game.
One way to launch it is by changing line 116 of StartActivity.java from
```  startActivity(new Intent(StartActivity.this, AboutActivity.class)); ```
to 
```  startActivity(new Intent(StartActivity.this, KillTheVirusGame.class)); ``` 
and then using ABOUT button on the main screen of app to launch the game.

![screenshot_2018-06-27-13-18-55-093_powerup systers com powerup](https://user-images.githubusercontent.com/26908195/41961691-c3441244-7a10-11e8-9a37-c03ecf01a2a9.png)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
