### PR TITLE
Added functionality to tutorial screen of Memory Match

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchTutorialActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchTutorialActivity.java
@@ -1,6 +1,7 @@
 package powerup.systers.com.memory_match_game;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.widget.Button;
@@ -14,35 +15,42 @@ import powerup.systers.com.R;
 
 public class MemoryMatchTutorialActivity extends Activity {
 
-
     @BindView(R.id.img_tile_2)
     public ImageView imgTile2;
     @BindView(R.id.img_tile_1)
     public ImageView imgTile1;
     @BindView(R.id.img_score)
     public ImageView imgScore;
-    @BindView(R.id.txt_score)
+    @BindView(R.id.txt_score_memory)
     public TextView txtScore;
     @BindView(R.id.txt_time_label)
     public TextView txtTimeLabel;
-    @BindView(R.id.txt_time)
+    @BindView(R.id.txt_time_memory)
     public TextView txtTime;
     @BindView(R.id.btn_yes)
     public Button btnYes;
     @BindView(R.id.btn_no)
     public Button btnNo;
     @BindView(R.id.btn_start)
-    public Button btnStart;
+    public ImageView btnStart;
     @BindView(R.id.txt_label_memory)
     public TextView txtMemoryLabel;
+    @BindView(R.id.txt_memory_tutorial_1)
+    public TextView txtTutorial1;
+    @BindView(R.id.txt_memory_tutorial_2)
+    public TextView txtTutorial2;
+    @BindView(R.id.txt_memory_tutorial_3)
+    public TextView txtTutorial3;
     public int tutorialCount;
+    private final float visible = 1, notVisible = (float) 0.7, gone = 0;
+    public boolean startFromActivity = true;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_memory_match_tutorial);
         ButterKnife.bind(this);
-
+        initializeViews();
     }
 
     @OnClick(R.id.layout_memory_match)
@@ -52,21 +60,57 @@ public class MemoryMatchTutorialActivity extends Activity {
         } else if (tutorialCount == 2) {
             showTutorial3();
         }
-        //        else {
-        //            Start the game
-        //        }
+        else{
+            startActivity(new Intent(MemoryMatchTutorialActivity.this, MemoryMatchGameActivity.class));
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+        }
     }
 
+    //Initialize the visibility of design elements according to first tutorial
     public void initializeViews() {
-        //TODO: Set the visibility according to first tutorial
+        if(startFromActivity) {
+            txtTutorial1.setAlpha(visible);
+            txtTutorial2.setAlpha(gone);
+            txtTutorial3.setAlpha(gone);
+            imgScore.setAlpha(notVisible);
+            txtScore.setAlpha(notVisible);
+            txtMemoryLabel.setAlpha(notVisible);
+            txtTime.setAlpha(notVisible);
+            txtTimeLabel.setAlpha(notVisible);
+            imgTile1.setAlpha(visible);
+            imgTile2.setAlpha(notVisible);
+            btnYes.setAlpha(notVisible);
+            btnNo.setAlpha(notVisible);
+            btnStart.setAlpha(gone);
+        }
+        tutorialCount = 1;
     }
 
+    //Initialize the visibility of design elements according to second tutorial
     public void showTutorial2() {
-        //TODO: Update the visibility of design elements
+        if(startFromActivity) {
+            txtTutorial1.setAlpha(gone);
+            txtTutorial2.setAlpha(visible);
+            imgTile1.setAlpha(notVisible);
+            btnYes.setAlpha(visible);
+            btnNo.setAlpha(visible);
+        }
+        tutorialCount = 2;
     }
 
+    //Initialize the visibility of design elements according to third tutorial
     public void showTutorial3() {
-        //TODO: Update the visibility of design elements
+        if(startFromActivity) {
+            txtTutorial2.setAlpha(gone);
+            txtTutorial3.setAlpha(visible);
+            imgScore.setAlpha(notVisible);
+            txtScore.setAlpha(notVisible);
+            txtMemoryLabel.setAlpha(notVisible);
+            txtTime.setAlpha(visible);
+            txtTimeLabel.setAlpha(visible);
+            btnYes.setAlpha(notVisible);
+            btnNo.setAlpha(notVisible);
+        }
+        tutorialCount = 3;
     }
-
 }

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/MemoryMatchTutorialTest.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/MemoryMatchTutorialTest.java
@@ -24,23 +24,27 @@ public class MemoryMatchTutorialTest {
 
     @Test
     public void tutorial1Test() {
+        memoryMatchTutorialActivity.startFromActivity = false;
         assertEquals(0, memoryMatchTutorialActivity.tutorialCount);
     }
 
     @Test
     public void tutorial2Test() {
+        memoryMatchTutorialActivity.startFromActivity = false;
         memoryMatchTutorialActivity.initializeViews();
         assertEquals(1, memoryMatchTutorialActivity.tutorialCount);
     }
 
     @Test
     public void tutorial3Test() {
+        memoryMatchTutorialActivity.startFromActivity = false;
         memoryMatchTutorialActivity.showTutorial2();
         assertEquals(2, memoryMatchTutorialActivity.tutorialCount);
     }
 
     @Test
     public void tutorialEndTest() {
+        memoryMatchTutorialActivity.startFromActivity = false;
         memoryMatchTutorialActivity.showTutorial3();
         assertEquals(3, memoryMatchTutorialActivity.tutorialCount);
     }


### PR DESCRIPTION
### Description

I have added functionality to the tutorial screen of mini game 2 such that all the tutorials are shown in proper sequence and then the game is started.

- Create a onClickListener() on whole layout so that the screen can be updated when touched anywhere
- Declare a count variable tutorialCount = 0, to change the alpha values of the design elements to make the proper tutorials visible
- The variables visiblie, notVisible and gone are used to set the value for alpha
- When tutorialCount is 0 first tutorial screen will be visible using function initializeViews()
- When tutorialCount is 1 second tutorial screen will be visible using function showTutorial2()
- When tutorialCount is 2 third tutorial screen will be visible using function showTutorial3()
- When tutorialCount is 3 -> intent transition from tutorial screen to main screen

Also, I have modified the tests so that all the tests pass

Fixes #1211 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Currently there is no direct option to trigger the mini game.
One way to launch it is by changing line 116 of StartActivity.java from
```  startActivity(new Intent(StartActivity.this, AboutActivity.class)); ```
to 
```  startActivity(new Intent(StartActivity.this, MemoryMatchTutorialActivity.class)); ``` 
and then using ABOUT button on the main screen of app to launch the game.

The tutorial screens that are displayed are: 

![35895361_1659479790836992_2515928886366175232_n](https://user-images.githubusercontent.com/26908195/41642050-de376312-7484-11e8-9cb8-0c9aadf83f06.png)

![35829011_1659479844170320_1193009711440461824_n](https://user-images.githubusercontent.com/26908195/41642059-e1769c50-7484-11e8-9de7-b5143a0cb27f.png)

![35812500_1659479800836991_3332348280381112320_n](https://user-images.githubusercontent.com/26908195/41642063-e4cc5962-7484-11e8-957a-aefd2720125c.png)

The tests pass successfully:

![tutorial test](https://user-images.githubusercontent.com/26908195/42132351-0fb69446-7d34-11e8-914c-b89abe34e289.png)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
