### PR TITLE
Add session manager for memory match

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchSessionManager.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchSessionManager.java
@@ -1,0 +1,78 @@
+package powerup.systers.com.memory_match_game;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+public class MemoryMatchSessionManager {
+
+    private final String GAME_OPENED = "IS_MEMORY_MATCH_OPENED";
+    private static final String CURR_SCORE = "currScore";
+    private static final String TIME_LEFT = "timeLeft";
+    private static final String CURR_TILE = "currTile";
+    private static final String PREVIOUS_TILE = "previousTile";
+    private static final String WRONG_ANSWERS = "wrongAnswers";
+    private static final String CORRECT_ANSWERS = "correctAnswers";
+    private final String PREF_NAME = "MEMORY_MATCH_PREFERENCE";
+    private final int PRIVATE_MODE = 0;
+
+    private SharedPreferences pref;
+    private Context context;
+    private SharedPreferences.Editor editor;
+    public MemoryMatchSessionManager(Context context) {
+        this.context = context;
+        pref = context.getSharedPreferences(PREF_NAME, PRIVATE_MODE);
+        editor = pref.edit();
+    }
+
+    public void saveData(int score, long timeLeft,int currentTile, int previousTile, int correctAnswers, int wrongAnswers){
+        editor.putInt(CURR_SCORE, score);
+        editor.putLong(TIME_LEFT, timeLeft);
+        editor.putInt(CURR_TILE, currentTile);
+        editor.putInt(PREVIOUS_TILE, previousTile);
+        editor.putInt(CORRECT_ANSWERS, correctAnswers);
+        editor.putInt(WRONG_ANSWERS, wrongAnswers);
+        Log.v("SESSION MANAGER","SAVING DATA");
+        Log.v("Score", "  " + score);
+        Log.v("Time Left", "  " + timeLeft);
+        Log.v("Current Tile", "  " + currentTile);
+        Log.v("Previous Tile", "  " + previousTile);
+        Log.v("Correct Answers", "  " + correctAnswers);
+        Log.v("Wrong Answer", "  " + wrongAnswers);
+        editor.commit();
+    }
+
+    public int getCurrScore() {
+        return pref.getInt(CURR_SCORE,0);
+    }
+
+    public long getTimeLeft() {
+        return pref.getLong(TIME_LEFT,0);
+    }
+
+    public int getCurrTile() {
+        return pref.getInt(CURR_TILE,0);
+    }
+
+    public int getPrevTile() {
+        return pref.getInt(PREVIOUS_TILE,0);
+    }
+
+    public int getWrongAnswer() {
+        return pref.getInt(WRONG_ANSWERS,0);
+    }
+
+    public int getCorrectAnswer() {
+        return pref.getInt(CORRECT_ANSWERS,0);
+    }
+
+    public boolean isSinkToSwimOpened() {
+        return pref.getBoolean(GAME_OPENED, false);
+    }
+
+    public void saveMemoryMatchOpenedStatus(boolean isOpened) {
+        editor.putBoolean(GAME_OPENED, isOpened);
+        editor.clear();
+        editor.commit();
+    }
+}

--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchTutorialActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchTutorialActivity.java
@@ -12,6 +12,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.R;
+import powerup.systers.com.powerup.PowerUpUtils;
 
 public class MemoryMatchTutorialActivity extends Activity {
 
@@ -61,7 +62,9 @@ public class MemoryMatchTutorialActivity extends Activity {
             showTutorial3();
         }
         else{
-            startActivity(new Intent(MemoryMatchTutorialActivity.this, MemoryMatchGameActivity.class));
+            Intent intent = new Intent(MemoryMatchTutorialActivity.this, MemoryMatchGameActivity.class);
+            intent.putExtra(PowerUpUtils.CALLED_BY, true);
+            startActivity(intent);
             overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
         }
     }


### PR DESCRIPTION
### Description

I have added MemoryMatchSessionManager.java to handle the case that if the mini game is left in the middle the states are saved and when it is relaunched, the values are initialized according to the saved ones.
 - saveData() is used to save all the required values 
- The various get functions are used to retrieve the saved values

Fixes #1221 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Since this is just a use case that if the migrates out to map in the middle of the mini game, there is no way to check it right now since the map for level 2 is not yet developed.
All the values that are saved are checked through log messages.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
