### PR TITLE
Fix the error in memory match

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
@@ -65,7 +65,7 @@ public class MemoryMatchGameActivity extends Activity {
         arrayTile = new ArrayList<>();
 
         boolean calledByTutorialActivity = getIntent().getBooleanExtra(PowerUpUtils.CALLED_BY, false);
-        if(calledByTutorialActivity){
+        if(!calledByTutorialActivity){
             MemoryMatchSessionManager sessionManager = new MemoryMatchSessionManager(this);
             score = sessionManager.getCurrScore();
             millisLeft = sessionManager.getTimeLeft();
@@ -77,9 +77,7 @@ public class MemoryMatchGameActivity extends Activity {
             btnStart.setVisibility(View.GONE);
             positionCount = 1;
             txtScore.setText(""+score);
-        }
-
-        else {
+        } else {
             //Setting the view of first tile
             position = random.nextInt(8);
             imgTile1.setImageResource(PowerUpUtils.MEMORY_GAME_TILE[position]);
@@ -149,6 +147,8 @@ public class MemoryMatchGameActivity extends Activity {
         translateTile.setAnimationListener(new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {
+                btnYes.setEnabled(false);
+                btnNo.setEnabled(false);
             }
 
             @Override
@@ -156,6 +156,8 @@ public class MemoryMatchGameActivity extends Activity {
                 position = random.nextInt(8);
                 imgTile1.setImageResource(PowerUpUtils.MEMORY_GAME_TILE[position]);
                 updateArray(position);
+                btnYes.setEnabled(true);
+                btnNo.setEnabled(true);
             }
 
             @Override


### PR DESCRIPTION
### Description
Added the mechanism to prevent user from scoring extra points in MemoryMatch by continously pressing yes/no button.
This is implemented by disabling the yes and no buttons while the linear animation of the tile is started and enabling them again when the animation is over.

Fixes #1230 

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue


### How Has This Been Tested?

Currently, there is no direct option to trigger the mini-game.
One way to launch it is by changing line 116 of StartActivity.java from
```  startActivity(new Intent(StartActivity.this, AboutActivity.class)); ```
to 
```  startActivity(new Intent(StartActivity.this,MemoryMatchGameActivity.class)); ``` 
and then using ABOUT button on the main screen of app to launch the game.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
