### PR TITLE
Adding mini game scores to total scores

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusGame.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusGame.java
@@ -25,6 +25,7 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.R;
 import powerup.systers.com.StartActivity;
+import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class KillTheVirusGame extends Activity {
@@ -175,6 +176,9 @@ public class KillTheVirusGame extends Activity {
         Intent intent = new Intent(KillTheVirusGame.this, KillTheVirusEndActivity.class);
         //Passing the final score using intent extra
         intent.putExtra(getString(R.string.score_kill_the_virus),totalScore);
+        //Adding mini-game scores
+        SessionHistory.totalPoints += score;
+        SessionHistory.currScenePoints += score;
         //End the Game
         startActivity(intent);
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);

--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
@@ -23,6 +23,7 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.R;
 import powerup.systers.com.StartActivity;
+import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class MemoryMatchGameActivity extends Activity {
@@ -194,6 +195,9 @@ public class MemoryMatchGameActivity extends Activity {
         intent.putExtra("score", score);
         intent.putExtra("wrong", wrongAnswer);
         intent.putExtra("correct", correctAnswer);
+        //Adding mini-game scores
+        SessionHistory.totalPoints += score;
+        SessionHistory.currScenePoints += score;
         startActivity(intent);
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }


### PR DESCRIPTION
### Description
I have code to add the points scored in minigames to total scenario points.

Fixes #1234 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Right now there is no way to launch the mini games.
The mini games are attached to scenarios in previous PRs.


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
