### PR TITLE
Add end screen for mini game 3

### DIFF
--- a/PowerUp/app/src/main/res/layout/activity_save_blood_end.xml
+++ b/PowerUp/app/src/main/res/layout/activity_save_blood_end.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/swim_game_end">
+
+    <TextView
+        android:id="@+id/txt_save_blood_score"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_zero"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/memory_score_txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.08"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.65" />
+
+    <TextView
+        android:id="@+id/txt_save_blood_correct"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_zero"
+        android:textColor="@color/correct_answer"
+        android:textSize="@dimen/memory_score_txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.65" />
+
+    <TextView
+        android:id="@+id/txt_memory_wrong"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_zero"
+        android:textColor="@color/cons_text"
+        android:textSize="@dimen/memory_score_txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.85"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.65" />
+
+    <ImageView
+        android:id="@+id/continue_btn_memory"
+        android:layout_width="@dimen/continue_height_memory"
+        android:layout_height="@dimen/continue_width_memory"
+        android:src="@drawable/continue_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
### Description
In this PR I have added xml layout for completion screen of mini game 3.

Fixes #1239 

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Currently there is no way to launch the screen since the PRs for level 2 have not been merged yet.

![35922879_1659535490831422_30619689436577792_n](https://user-images.githubusercontent.com/26908195/42721651-f2f3ad8a-875b-11e8-9dde-14972fa23e04.png)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
