### PR TITLE
Add tutorial screens for mini game 3

### DIFF
--- a/PowerUp/app/src/main/res/layout/activity_save_the_blood_game.xml
+++ b/PowerUp/app/src/main/res/layout/activity_save_the_blood_game.xml
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/vocab_bg">
+
+    <ImageView
+        android:id="@+id/img_option_1"
+        android:layout_width="@dimen/save_blood_box_width"
+        android:layout_height="@dimen/save_blood_box_height"
+        android:layout_marginEnd="8dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/left_conversation"
+        app:layout_constraintBottom_toBottomOf="@+id/img_option_4"
+        app:layout_constraintEnd_toStartOf="@+id/img_option_2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.35000002" />
+
+    <ImageView
+        android:id="@+id/img_option_3"
+        android:layout_width="@dimen/save_blood_box_width"
+        android:layout_height="@dimen/save_blood_box_height"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/left_conversation"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/img_option_2"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.3" />
+
+    <ImageView
+        android:id="@+id/img_option_4"
+        android:layout_width="@dimen/save_blood_box_width"
+        android:layout_height="@dimen/save_blood_box_height"
+        android:src="@drawable/left_conversation"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/img_option_5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.85" />
+
+    <ImageView
+        android:id="@+id/img_option_6"
+        android:layout_width="@dimen/save_blood_box_width"
+        android:layout_height="@dimen/save_blood_box_height"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/left_conversation"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/img_option_5"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.85" />
+
+    <ImageView
+        android:id="@+id/img_option_2"
+        android:layout_width="@dimen/save_blood_box_width"
+        android:layout_height="@dimen/save_blood_box_height"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/left_conversation"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.3" />
+
+    <ImageView
+        android:id="@+id/img_option_5"
+        android:layout_width="@dimen/save_blood_box_width"
+        android:layout_height="@dimen/save_blood_box_height"
+        android:src="@drawable/left_conversation"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.85" />
+
+    <ImageView
+        android:id="@+id/img_score"
+        android:layout_width="@dimen/score_label_size"
+        android:layout_height="@dimen/score_label_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:src="@drawable/vocab_score" />
+
+    <TextView
+        android:id="@+id/txt_time_label_save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/time"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toStartOf="@+id/txt_time_save"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/txt_time_save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/txt_zero"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/txt_score_save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/txt_zero"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/img_score"
+        app:layout_constraintEnd_toEndOf="@+id/img_score"
+        app:layout_constraintHorizontal_bias="0.25"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.57" />
+
+    <TextView
+        android:id="@+id/txt_save_blood_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="20dp"
+        android:text="@string/save_the_blood_label"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toStartOf="@+id/txt_time_label_save"
+        app:layout_constraintStart_toEndOf="@+id/img_score"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/txt_option_6"
+        android:layout_width="@dimen/option_width"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_answer_correct"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/img_option_6"
+        app:layout_constraintEnd_toEndOf="@+id/img_option_6"
+        app:layout_constraintStart_toStartOf="@+id/img_option_6"
+        app:layout_constraintTop_toTopOf="@+id/img_option_6" />
+
+    <TextView
+        android:id="@+id/txt_option_5"
+        android:layout_width="@dimen/option_width"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_answer_wrong"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/img_option_5"
+        app:layout_constraintEnd_toEndOf="@+id/img_option_5"
+        app:layout_constraintStart_toStartOf="@+id/img_option_5"
+        app:layout_constraintTop_toTopOf="@+id/img_option_5" />
+
+    <TextView
+        android:id="@+id/txt_option_4"
+        android:layout_width="@dimen/option_width"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_answer_neutral"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/img_option_4"
+        app:layout_constraintEnd_toEndOf="@+id/img_option_4"
+        app:layout_constraintStart_toStartOf="@+id/img_option_4"
+        app:layout_constraintTop_toTopOf="@+id/img_option_4" />
+
+    <TextView
+        android:id="@+id/txt_option_3"
+        android:layout_width="@dimen/option_width"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_answer_correct"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/img_option_3"
+        app:layout_constraintEnd_toEndOf="@+id/img_option_3"
+        app:layout_constraintStart_toStartOf="@+id/img_option_3"
+        app:layout_constraintTop_toTopOf="@+id/img_option_3" />
+
+    <TextView
+        android:id="@+id/txt_option_2"
+        android:layout_width="@dimen/option_width"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_answer_wrong"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/img_option_2"
+        app:layout_constraintEnd_toEndOf="@+id/img_option_2"
+        app:layout_constraintStart_toStartOf="@+id/img_option_2"
+        app:layout_constraintTop_toTopOf="@+id/img_option_2" />
+
+    <TextView
+        android:id="@+id/txt_option_1"
+        android:layout_width="@dimen/option_width"
+        android:layout_height="wrap_content"
+        android:text="@string/txt_answer_neutral"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/img_option_1"
+        app:layout_constraintEnd_toEndOf="@+id/img_option_1"
+        app:layout_constraintStart_toStartOf="@+id/img_option_1"
+        app:layout_constraintTop_toTopOf="@+id/img_option_1" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="13dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:scaleY="5"
+        android:progress="@integer/half_progress"/>
+
+
+</android.support.constraint.ConstraintLayout>

--- a/PowerUp/app/src/main/res/layout/actvity_save_blood_tutorial.xml
+++ b/PowerUp/app/src/main/res/layout/actvity_save_blood_tutorial.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        layout="@layout/activity_save_the_blood_game"/>
+
+    <TextView
+        android:id="@+id/save_blood_txt_tutorial_1"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/btn_bg"
+        android:padding="@dimen/margin_small"
+        android:text="@string/save_blood_tutorial_1"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/save_blood_txt_tutorial_2"
+        android:layout_width="145dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/btn_bg"
+        android:padding="@dimen/margin_small"
+        android:text="@string/save_blood_tutorial_2"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.73" />
+
+    <TextView
+        android:id="@+id/save_blood_txt_tutorial_3"
+        android:layout_width="190dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/btn_bg"
+        android:padding="@dimen/margin_small"
+        android:text="@string/save_blood_tutorial_3"
+        android:textColor="@color/powerup_dark_blue"
+        android:textSize="@dimen/txt_size"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.71"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+</android.support.constraint.ConstraintLayout>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -51,5 +51,8 @@
     <dimen name="memory_tutorial_1_width">250dp</dimen>
     <dimen name="memory_tutorial_2_width">178dp</dimen>
     <dimen name="memory_tutorial_3_width">220dp</dimen>
+    <dimen name="save_blood_box_width">175dp</dimen>
+    <dimen name="save_blood_box_height">115dp</dimen>
+    <dimen name="option_width">90dp</dimen>
 </resources>
 

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -118,4 +118,8 @@
     <string name="txt_three_zero">30</string>
     <string name="lives_label">Lives:</string>
     <string name="txt_3">3</string>
+    <string name="save_the_blood_label">Presented Situation 1</string>
+    <string name="txt_answer_correct">Answer = Correct</string>
+    <string name="txt_answer_wrong">Answer = Wrong</string>
+    <string name="txt_answer_neutral">Answer = Neutral</string>
 </resources>

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -122,4 +122,7 @@
     <string name="txt_answer_correct">Answer = Correct</string>
     <string name="txt_answer_wrong">Answer = Wrong</string>
     <string name="txt_answer_neutral">Answer = Neutral</string>
+    <string name="save_blood_tutorial_1">Choose the answers that you think might fit the situation!</string>
+    <string name="save_blood_tutorial_2">Every correct answer will increase the level of blood!</string>
+    <string name="save_blood_tutorial_3">Try to choose all the correct options before the time runs out!</string>
 </resources>


### PR DESCRIPTION
### Description

In this PR, I have added xml layout for tutorial screen of mini game 3.
Right now it has text view. Later, I will modify it to show the textviews separately as implemented in previous mini games.

Fixes #1238 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Currently there is no way to launch the screen since the PRs for level 2 have not been merged yet.

![37145882_1695765780541726_3315003024891445248_n](https://user-images.githubusercontent.com/26908195/42722375-9035888c-8768-11e8-9428-f15b787c21fd.png)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] Any dependent changes have been published in downstream modules
