### PR TITLE
Added functionality to game completion screen of mini game 3

### DIFF
--- a/PowerUp/app/src/main/AndroidManifest.xml
+++ b/PowerUp/app/src/main/AndroidManifest.xml
@@ -210,6 +210,13 @@
             android:screenOrientation="landscape"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
+        <activity
+            android:name=".save_the_blood_game.SaveTheBloodEndActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:label="@string/app_name"
+            android:screenOrientation="landscape"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+
         <service android:name=".MinesweeperSound" />
         <service android:name=".sink_to_swim_game.SinkToSwimSound" />
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodEndActivity.java
@@ -1,0 +1,54 @@
+package powerup.systers.com.save_the_blood_game;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.widget.TextView;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import powerup.systers.com.R;
+import powerup.systers.com.ScenarioOverLevel2Activity;
+import powerup.systers.com.powerup.PowerUpUtils;
+
+public class SaveTheBloodEndActivity extends Activity {
+
+    @BindView(R.id.txt_save_blood_score)
+    public TextView txtScore;
+    @BindView(R.id.txt_save_blood_correct)
+    public TextView txtCorrect;
+    @BindView(R.id.txt_save_blood_wrong)
+    public TextView txtWrong;
+    public int score, correct, wrong;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_save_blood_end);
+        ButterKnife.bind(this);
+        getValues();
+        updateViews();
+    }
+
+    @OnClick(R.id.btn_continue_save_blood)
+    public void clickContinue(){
+        Intent intent = new Intent(SaveTheBloodEndActivity.this, ScenarioOverLevel2Activity.class);
+        intent.putExtra(PowerUpUtils.IS_FINAL_SCENARIO_EXTRA, true);
+        startActivity(intent);
+        overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+    }
+
+    public void updateViews(){
+        txtScore.setText(""+score);
+        txtCorrect.setText(""+correct);
+        txtWrong.setText(""+wrong);
+    }
+
+    public void getValues(){
+        score = getIntent().getIntExtra("score", 0);
+        correct = getIntent().getIntExtra("correct",0);
+        wrong = getIntent().getIntExtra("wrong", 0);
+    }
+}

--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodGameActivity.java
@@ -241,18 +241,20 @@ public class SaveTheBloodGameActivity extends Activity {
     /**
      * Save all the required values
      */
-    public void gameEnd() {
-        Intent intent = new Intent(SaveTheBloodGameActivity.this, ScenarioOverLevel2Activity.class);
-        intent.putExtra(PowerUpUtils.IS_FINAL_SCENARIO_EXTRA, true);
-        countDownTimer.cancel();
-        SessionHistory.totalPoints += score;
-        SessionHistory.currScenePoints += score;
-        Log.v("SaveBloodGameActivity", "Score: " + score);
-        Log.v("SaveBloodGameActivity", "Correct answers: " + correctAnswer);
-        Log.v("SaveBloodGameActivity", "Wrong answers " + wrongAnswer);
-        startActivity(intent);
-        overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
-    }
+     public void gameEnd() {
+                Intent intent = new Intent(SaveTheBloodGameActivity.this, SaveTheBloodEndActivity.class);
+                intent.putExtra("score", score);
+                intent.putExtra("correct", correctAnswer);
+                intent.putExtra("wrong", wrongAnswer);
+                countDownTimer.cancel();
+                SessionHistory.totalPoints += score;
+                SessionHistory.currScenePoints += score;
+                Log.v("SaveBloodGameActivity", "Score: " + score);
+                Log.v("SaveBloodGameActivity", "Correct answers: " + correctAnswer);
+                Log.v("SaveBloodGameActivity", "Wrong answers " + wrongAnswer);
+                startActivity(intent);
+                overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+     }
 
     @Override
     public void onBackPressed() {

--- a/PowerUp/app/src/main/res/layout/activity_save_blood_end.xml
+++ b/PowerUp/app/src/main/res/layout/activity_save_blood_end.xml
@@ -35,7 +35,7 @@
         app:layout_constraintVertical_bias="0.65" />
 
     <TextView
-        android:id="@+id/txt_memory_wrong"
+        android:id="@+id/txt_save_blood_wrong"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/txt_zero"
@@ -50,7 +50,7 @@
         app:layout_constraintVertical_bias="0.65" />
 
     <ImageView
-        android:id="@+id/continue_btn_memory"
+        android:id="@+id/btn_continue_save_blood"
         android:layout_width="@dimen/continue_height_memory"
         android:layout_height="@dimen/continue_width_memory"
         android:src="@drawable/continue_button"


### PR DESCRIPTION
### Description
The PR adds functionality to game completion screen such that,
 - Values of score and number of correct and wrong answer is passed on from game main screen to end screen
 - The screen appears after main screen
 - Pressing continue launches scenario completion scenario

Fixes #1245 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

The screen can be launched after completion of the mini game
![end](https://user-images.githubusercontent.com/26908195/42765245-31d32212-8935-11e8-8d41-4694c39aa5cc.png)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
