### PR TITLE
Add functionality to tutorial screens of memory match

### DIFF
--- a/PowerUp/app/src/main/AndroidManifest.xml
+++ b/PowerUp/app/src/main/AndroidManifest.xml
@@ -210,6 +210,13 @@
             android:screenOrientation="landscape"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
+        <activity
+            android:name=".save_the_blood_game.SaveTheBloodTutorialActivity"
+            android:configChanges="orientation|keyboardHidden"
+            android:label="@string/app_name"
+            android:screenOrientation="landscape"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+
         <service android:name=".MinesweeperSound" />
         <service android:name=".sink_to_swim_game.SinkToSwimSound" />
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/GameLevel2Activity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameLevel2Activity.java
@@ -36,7 +36,7 @@ import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.kill_the_virus_game.KillTheVirusTutorials;
 import powerup.systers.com.powerup.PowerUpUtils;
-import powerup.systers.com.save_the_blood_game.SaveTheBloodGameActivity;
+import powerup.systers.com.save_the_blood_game.SaveTheBloodTutorialActivity;
 import powerup.systers.com.vocab_match_game.VocabMatchTutorials;
 
 @SuppressLint("NewApi")
@@ -257,7 +257,7 @@ public class GameLevel2Activity extends Activity {
                 startActivity(new Intent(GameLevel2Activity.this, VocabMatchTutorials.class));
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
             } else if (type == -11) {
-                startActivity(new Intent(GameLevel2Activity.this, SaveTheBloodGameActivity.class));
+                startActivity(new Intent(GameLevel2Activity.this, SaveTheBloodTutorialActivity.class));
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
             }
         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodGameActivity.java
@@ -257,6 +257,7 @@ public class SaveTheBloodGameActivity extends Activity {
     @Override
     public void onBackPressed() {
         super.onBackPressed();
+        countDownTimer.cancel();
         startActivity(new Intent(SaveTheBloodGameActivity.this, MapLevel2Activity.class));
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodTutorialActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodTutorialActivity.java
@@ -1,0 +1,131 @@
+package powerup.systers.com.save_the_blood_game;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.widget.ImageView;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import powerup.systers.com.R;
+
+public class SaveTheBloodTutorialActivity extends Activity {
+
+    @BindView(R.id.save_blood_txt_tutorial_1)
+    public TextView txtTutorial1;
+    @BindView(R.id.save_blood_txt_tutorial_2)
+    public TextView txtTutorial2;
+    @BindView(R.id.save_blood_txt_tutorial_3)
+    public TextView txtTutorial3;
+    @BindView(R.id.txt_score_save)
+    public TextView txtScore;
+    @BindView(R.id.img_score_save)
+    public ImageView imgScore;
+    @BindView(R.id.txt_time_save)
+    public TextView txtTime;
+    @BindView(R.id.txt_save_blood_label)
+    public TextView txtSituation;
+    @BindView(R.id.txt_option_1)
+    public TextView txtOption1;
+    @BindView(R.id.txt_option_2)
+    public TextView txtOption2;
+    @BindView(R.id.txt_option_3)
+    public TextView txtOption3;
+    @BindView(R.id.txt_option_4)
+    public TextView txtOption4;
+    @BindView(R.id.txt_option_5)
+    public TextView txtOption5;
+    @BindView(R.id.txt_option_6)
+    public TextView txtOption6;
+    @BindView(R.id.txt_time_label_save)
+    public TextView txtTimeLabel;
+    @BindView(R.id.progress_bar)
+    public ProgressBar progressBar;
+    @BindView(R.id.img_option_1)
+    public ImageView imgOption1;
+    @BindView(R.id.img_option_2)
+    public ImageView imgOption2;
+    @BindView(R.id.img_option_3)
+    public ImageView imgOption3;
+    @BindView(R.id.img_option_4)
+    public ImageView imgOption4;
+    @BindView(R.id.img_option_5)
+    public ImageView imgOption5;
+    @BindView(R.id.img_option_6)
+    public ImageView imgOption6;
+    public int tutorialCount = 0;
+    private final float visible = 1, notVisible = (float) 0.7, gone = 0;
+    public boolean startFromActivity = true;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.actvity_save_blood_tutorial);
+        ButterKnife.bind(this);
+        initializeViews();
+    }
+
+    @OnClick(R.id.layout_save_blood)
+    public void clickScreen(){
+        if(tutorialCount == 1)
+            showTutorial2();
+        else if(tutorialCount == 2)
+            showTutorial3();
+        else {
+            startActivity(new Intent(SaveTheBloodTutorialActivity.this, SaveTheBloodGameActivity.class));
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+        }
+    }
+
+    public void initializeViews(){
+        if(startFromActivity) {
+            txtTutorial1.setAlpha(visible);
+            txtTutorial2.setAlpha(gone);
+            txtTutorial3.setAlpha(gone);
+            txtScore.setAlpha(notVisible);
+            imgScore.setAlpha(notVisible);
+            txtTime.setAlpha(notVisible);
+            txtTimeLabel.setAlpha(notVisible);
+            txtSituation.setAlpha(visible);
+            progressBar.setAlpha(notVisible);
+            imgOption1.setAlpha(notVisible);
+            imgOption2.setAlpha(notVisible);
+            imgOption3.setAlpha(notVisible);
+            imgOption4.setAlpha(notVisible);
+            imgOption5.setAlpha(notVisible);
+            imgOption6.setAlpha(notVisible);
+        }
+        tutorialCount = 1;
+    }
+
+    public void showTutorial2(){
+        if(startFromActivity) {
+            txtTutorial1.setAlpha(gone);
+            txtTutorial2.setAlpha(visible);
+            txtSituation.setAlpha(notVisible);
+            txtOption1.setAlpha(notVisible);
+            txtOption2.setAlpha(notVisible);
+            txtOption3.setAlpha(notVisible);
+            txtOption4.setAlpha(notVisible);
+            txtOption5.setAlpha(notVisible);
+            txtOption6.setAlpha(notVisible);
+            progressBar.setAlpha(visible);
+        }
+        tutorialCount = 2;
+    }
+
+    public void showTutorial3(){
+        if(startFromActivity) {
+            txtTutorial2.setAlpha(gone);
+            txtTutorial3.setAlpha(visible);
+            txtTime.setAlpha(visible);
+            txtTimeLabel.setAlpha(visible);
+            progressBar.setAlpha(notVisible);
+        }
+        tutorialCount = 3;
+    }
+}

--- a/PowerUp/app/src/main/res/layout/activity_save_the_blood_game.xml
+++ b/PowerUp/app/src/main/res/layout/activity_save_the_blood_game.xml
@@ -80,7 +80,7 @@
         app:layout_constraintVertical_bias="0.85" />
 
     <ImageView
-        android:id="@+id/img_score"
+        android:id="@+id/img_score_save"
         android:layout_width="@dimen/score_label_size"
         android:layout_height="@dimen/score_label_size"
         app:layout_constraintStart_toStartOf="parent"
@@ -116,34 +116,30 @@
         android:id="@+id/txt_score_save"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
         android:text="@string/txt_zero"
         android:textColor="@color/powerup_dark_blue"
         android:textSize="@dimen/txt_size"
         android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="@+id/img_score"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/img_score"
         app:layout_constraintHorizontal_bias="0.25"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.57" />
+        app:layout_constraintVertical_bias="0.13999999" />
 
     <TextView
         android:id="@+id/txt_save_blood_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="20dp"
         android:text="@string/save_the_blood_label"
         android:textColor="@color/powerup_dark_blue"
         android:textSize="@dimen/txt_size"
         android:textStyle="bold"
         app:layout_constraintEnd_toStartOf="@+id/txt_time_label_save"
-        app:layout_constraintStart_toEndOf="@+id/img_score"
+        app:layout_constraintStart_toStartOf="@+id/txt_score_save"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView

--- a/PowerUp/app/src/main/res/layout/actvity_save_blood_tutorial.xml
+++ b/PowerUp/app/src/main/res/layout/actvity_save_blood_tutorial.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/layout_save_blood">
 
     <include
         layout="@layout/activity_save_the_blood_game"/>

--- a/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SaveTheBloodTutorialTests.java
+++ b/PowerUp/app/src/test/java/powerup/systers/com/powerup/test/SaveTheBloodTutorialTests.java
@@ -1,0 +1,50 @@
+package powerup.systers.com.powerup.test;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+
+import powerup.systers.com.save_the_blood_game.SaveTheBloodTutorialActivity;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(JUnit4.class)
+public class SaveTheBloodTutorialTests {
+
+    @Mock
+    private SaveTheBloodTutorialActivity saveTheBloodTutorialActivity;
+
+    @Before
+    public void setSaveTheBloodTutorialActivity(){
+        saveTheBloodTutorialActivity = new SaveTheBloodTutorialActivity();
+    }
+
+    @Test
+    public void tutorial1Test() {
+        saveTheBloodTutorialActivity.startFromActivity = false;
+        assertEquals(0, saveTheBloodTutorialActivity.tutorialCount);
+    }
+
+    @Test
+    public void tutorial2Test() {
+        saveTheBloodTutorialActivity.startFromActivity = false;
+        saveTheBloodTutorialActivity.initializeViews();
+        assertEquals(1, saveTheBloodTutorialActivity.tutorialCount);
+    }
+
+    @Test
+    public void tutorial3Test() {
+        saveTheBloodTutorialActivity.startFromActivity = false;
+        saveTheBloodTutorialActivity.showTutorial2();
+        assertEquals(2, saveTheBloodTutorialActivity.tutorialCount);
+    }
+
+    @Test
+    public void tutorialEndTest() {
+        saveTheBloodTutorialActivity.startFromActivity = false;
+        saveTheBloodTutorialActivity.showTutorial3();
+        assertEquals(3, saveTheBloodTutorialActivity.tutorialCount);
+    }
+}


### PR DESCRIPTION
### Description
I have added functionality to the tutorial screen of mini game 3 such that all the tutorials are shown in proper sequence and then the game is started.

- Create a onClickListener() on whole layout so that the screen can be updated when touched anywhere
- Declare a count variable tutorialCount = 0, to change the alpha values of the design elements to make the proper tutorials visible
- The variables visiblie, notVisible and gone are used to set the value for alpha
- When tutorialCount is 0 first tutorial screen will be visible using function initializeViews()
- When tutorialCount is 1 second tutorial screen will be visible using function showTutorial2()
- When tutorialCount is 2 third tutorial screen will be visible using function showTutorial3()
- When tutorialCount is 3 -> intent transition from tutorial screen to main screen

Also, I have added assertion tests and all the tests pass.

Fixes #1246 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

The tutorial screens are launched just after the completion of Library scenario in Level 2

![videotogif_2018 07 17_23 29 23](https://user-images.githubusercontent.com/26908195/42839525-9c53cb90-8a21-11e8-87d7-a9abde2ea075.gif)

![save tests](https://user-images.githubusercontent.com/26908195/42839463-7238a146-8a21-11e8-94f0-052438769823.png)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
