### PR TITLE
Added session manager for mini game 3

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodGameActivity.java
@@ -260,4 +260,13 @@ public class SaveTheBloodGameActivity extends Activity {
         startActivity(new Intent(SaveTheBloodGameActivity.this, MapLevel2Activity.class));
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }
+
+    @Override
+    protected void onPause() {
+        SaveTheBloodSessionManager sessionManager = new SaveTheBloodSessionManager(this);
+        sessionManager.saveData(score, millisLeft, count, correctAnswer, wrongAnswer, progress);
+        countDownTimer.cancel();
+        countDownTimer = null;
+        super.onPause();
+    }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodSessionManager.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodSessionManager.java
@@ -1,0 +1,76 @@
+package powerup.systers.com.save_the_blood_game;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+public class SaveTheBloodSessionManager {
+
+    private final String GAME_OPENED = "IS_SAVE_BLOOD_OPENED";
+    private static final String CURR_SCORE = "currScore";
+    private static final String TIME_LEFT = "timeLeft";
+    private static final String CURR_ROUND = "currRound";
+    private static final String WRONG_ANSWERS = "wrongAnswers";
+    private static final String CORRECT_ANSWERS = "correctAnswers";
+    private static final String CURR_PROGRESS = "currProgress";
+    private final String PREF_NAME = "SAVE_BLOOD_PREFERENCE";
+    private final int PRIVATE_MODE = 0;
+
+    private SharedPreferences pref;
+    private SharedPreferences.Editor editor;
+    public SaveTheBloodSessionManager(Context context) {
+        pref = context.getSharedPreferences(PREF_NAME, PRIVATE_MODE);
+        editor = pref.edit();
+    }
+
+    public void saveData(int score, long timeLeft,int currRound, int correctAnswers, int wrongAnswers, int progress) {
+        editor.putInt(CURR_SCORE, score);
+        editor.putLong(TIME_LEFT, timeLeft);
+        editor.putInt(CURR_ROUND, currRound);
+        editor.putInt(CORRECT_ANSWERS, correctAnswers);
+        editor.putInt(WRONG_ANSWERS, wrongAnswers);
+        editor.putInt(CURR_PROGRESS, progress);
+        Log.v("SaveBloodSessionManager","Saving Data");
+        Log.v("SaveBloodSessionManager", "Score: " + score);
+        Log.v("SaveBloodSessionManager", "Time Left: " + timeLeft);
+        Log.v("SaveBloodSessionManager", "Current Round: " + currRound);
+        Log.v("SaveBloodSessionManager", "  " + correctAnswers);
+        Log.v("SaveBloodSessionManager", "  " + wrongAnswers);
+        Log.v("SaveBloodSessionManager", "Current Progress: " + progress);
+        editor.commit();
+    }
+
+    public int getCurrScore() {
+        return pref.getInt(CURR_SCORE,0);
+    }
+
+    public long getTimeLeft() {
+        return pref.getLong(TIME_LEFT,0);
+    }
+
+    public int getCurrRound(){
+        return pref.getInt(CURR_ROUND, 0);
+    }
+
+    public int getWrongAnswer() {
+        return pref.getInt(WRONG_ANSWERS,0);
+    }
+
+    public int getCorrectAnswer() {
+        return pref.getInt(CORRECT_ANSWERS,0);
+    }
+
+    public int getCurrentProgress() {
+        return pref.getInt(CURR_PROGRESS,0);
+    }
+
+    public boolean isSaveBloodOpened() {
+        return pref.getBoolean(GAME_OPENED, false);
+    }
+
+    public void saveSaveBloodOpenedStatus(boolean isOpened) {
+        editor.putBoolean(GAME_OPENED, isOpened);
+        editor.clear();
+        editor.commit();
+    }
+}


### PR DESCRIPTION
### Description

I have added SaveBloodSessionManagerr.java to handle the case that if the mini game is left in the middle the states are saved and when it is relaunched, the values are initialized according to the saved ones.
 - saveData() is used to save all the required values
- The getter functions are used to retrieve the saved values

Fixes #1250 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Since all the files related to mini game 3 are not yet merged, I have not attached the session manager to the mini game and there isn't anyway to check it.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
