### PR TITLE
Attached session manager in Kill the Virus

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameLevel2Activity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameLevel2Activity.java
@@ -34,6 +34,8 @@ import powerup.systers.com.datamodel.Question;
 import powerup.systers.com.datamodel.Scenario;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
+import powerup.systers.com.kill_the_virus_game.KillTheVirusGame;
+import powerup.systers.com.kill_the_virus_game.KillTheVirusSessionManager;
 import powerup.systers.com.kill_the_virus_game.KillTheVirusTutorials;
 import powerup.systers.com.powerup.PowerUpUtils;
 import powerup.systers.com.save_the_blood_game.SaveTheBloodGameActivity;
@@ -84,6 +86,11 @@ public class GameLevel2Activity extends Activity {
         getmDbHandler().open();
         setContentView(R.layout.game_activity);
         ButterKnife.bind(this);
+
+        if(new KillTheVirusSessionManager(this).isKillTheVirusOpened()){
+            startActivity(new Intent(GameLevel2Activity.this, KillTheVirusGame.class));
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+        }
 
         // Find the ListView resource.
         listAdapter = new ArrayAdapter<>(this, R.layout.simplerow, new ArrayList<String>());
@@ -251,6 +258,7 @@ public class GameLevel2Activity extends Activity {
                 startActivity(new Intent(GameLevel2Activity.this, ScenarioOverLevel2Activity.class));
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
             } else if (type == -8) {
+                new KillTheVirusSessionManager(this).saveKillTheVirusOpenedStatus(true);
                 startActivity(new Intent(GameLevel2Activity.this, KillTheVirusTutorials.class));
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
             } else if (type == -10) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapLevel2Activity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapLevel2Activity.java
@@ -19,6 +19,8 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
+import powerup.systers.com.kill_the_virus_game.KillTheVirusGame;
+import powerup.systers.com.kill_the_virus_game.KillTheVirusSessionManager;
 import powerup.systers.com.powerup.PowerUpUtils;
 
 public class MapLevel2Activity extends Activity {
@@ -48,6 +50,9 @@ public class MapLevel2Activity extends Activity {
             if (v.isEnabled()) {
                 if (getmDbHandler().setSessionId(getScenarioName(scenarioChooser.getId()))) {
                     startActivityForResult(new Intent(MapLevel2Activity.this, GameLevel2Activity.class), 0);
+                    overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+                } else if(new KillTheVirusSessionManager(MapLevel2Activity.this).isKillTheVirusOpened()){
+                    startActivity(new Intent(MapLevel2Activity.this, KillTheVirusGame.class));
                     overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                 } else {
                     Intent intent = new Intent(MapLevel2Activity.this, ScenarioOverLevel2Activity.class);

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -22,6 +22,7 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import powerup.systers.com.datamodel.SessionHistory;
+import powerup.systers.com.kill_the_virus_game.KillTheVirusSessionManager;
 import powerup.systers.com.minesweeper.MinesweeperSessionManager;
 import powerup.systers.com.sink_to_swim_game.SinkToSwimSessionManager;
 import powerup.systers.com.vocab_match_game.VocabMatchSessionManager;
@@ -61,6 +62,8 @@ public class StartActivity extends Activity {
                                 .saveSinkToSwimOpenedStatus(false);
                             new VocabMatchSessionManager(StartActivity.this)
                                 .saveVocabMatchOpenedStatus(false);
+                            new KillTheVirusSessionManager(StartActivity.this)
+                                    .saveKillTheVirusOpenedStatus(false);
                             startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
                             overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusEndActivity.java
@@ -27,6 +27,7 @@ public class KillTheVirusEndActivity extends Activity {
 
     @OnClick(R.id.btn_continue_memory)
     public void clickContinue() {
+        new KillTheVirusSessionManager(this).saveKillTheVirusOpenedStatus(false);
         startActivity(new Intent(KillTheVirusEndActivity.this, ScenarioOverLevel2Activity.class));
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusGame.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusGame.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import powerup.systers.com.MapLevel2Activity;
 import powerup.systers.com.R;
 import powerup.systers.com.StartActivity;
 import powerup.systers.com.datamodel.SessionHistory;
@@ -95,6 +96,8 @@ public class KillTheVirusGame extends Activity {
             millisLeft = session.getTime();
             lives = session.getLives();
             duration = session.getSpeed();
+            txtScore.setText(""+score);
+            txtLives.setText(""+lives);
             for(int i = 1; i<= 8; i++){
                 if(PowerUpUtils.VIRUS_HIT[i])
                     imgVirusArray[i].setVisibility(View.GONE);
@@ -287,7 +290,7 @@ public class KillTheVirusGame extends Activity {
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-        startActivity(new Intent(KillTheVirusGame.this, StartActivity.class));
+        startActivity(new Intent(KillTheVirusGame.this, MapLevel2Activity.class));
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusSessionManager.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusSessionManager.java
@@ -18,7 +18,7 @@ public class KillTheVirusSessionManager {
     private Context context;
     private SharedPreferences.Editor editor;
 
-    KillTheVirusSessionManager(Context context) {
+    public KillTheVirusSessionManager(Context context) {
         this.context = context;
         pref = context.getSharedPreferences(PREF_NAME, PRIVATE_MODE);
         editor = pref.edit();

--- a/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusTutorials.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/kill_the_virus_game/KillTheVirusTutorials.java
@@ -60,6 +60,10 @@ public class KillTheVirusTutorials extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_kill_the_virus_tutorial);
         ButterKnife.bind(this);
+
+        //Resetting the array
+        for(int i = 1; i<= 8; i++)
+                PowerUpUtils.VIRUS_HIT[i] = false;
         initializeViews();
     }
 


### PR DESCRIPTION
### Description

In this PR, I have attached session manager to mini-game. The logis here is if the mini game was left in middle it is considered as still open and the value is set accordingly in saveKillTheVirusOpenedStatus(). Additionally, the values of all the variables in onPause().
Now when a scenario is clicked, first it is checked whether the mini-game was saved as open or not using isKillTheVirusOpened(). If it was opened first the mini-game is launched and all the variables are set according to the values stored in shared preferences.

Fixes #1252

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

The functionality can be tested by leaving the mini game in the middle and then pressing home or school on map again.

![videotogif_2018 07 18_22 29 10](https://user-images.githubusercontent.com/26908195/42897625-2b711d84-8ade-11e8-86f6-8a4a7043ffb1.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
