### PR TITLE
Added session manager to Memory Match

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameActivity.java
@@ -31,6 +31,8 @@ import powerup.systers.com.datamodel.Question;
 import powerup.systers.com.datamodel.Scenario;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
+import powerup.systers.com.memory_match_game.MemoryMatchGameActivity;
+import powerup.systers.com.memory_match_game.MemoryMatchSessionManager;
 import powerup.systers.com.memory_match_game.MemoryMatchTutorialActivity;
 import powerup.systers.com.minesweeper.MinesweeperGameActivity;
 import powerup.systers.com.minesweeper.MinesweeperSessionManager;
@@ -71,6 +73,10 @@ public class GameActivity extends Activity {
         }
         if(new SinkToSwimSessionManager(this).isSinkToSwimOpened()) {
             startActivity(new Intent(GameActivity.this, SinkToSwimGame.class));
+        }
+        if(new MemoryMatchSessionManager(this).isMemoryMatchOpened()){
+            startActivity(new Intent(GameActivity.this, MemoryMatchGameActivity.class));
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
         }
         if (savedInstanceState != null) {
             isStateChanged = true;
@@ -281,6 +287,7 @@ public class GameActivity extends Activity {
                 startActivity(new Intent(GameActivity.this, SinkToSwimTutorials.class));
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
             } else if (type == -3) {
+                new MemoryMatchSessionManager(this).saveMemoryMatchOpenedStatus(true);
                 startActivity(new Intent(GameActivity.this, MemoryMatchTutorialActivity.class));
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
             }

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapActivity.java
@@ -16,6 +16,8 @@ import android.widget.ImageView;
 
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.db.DatabaseHandler;
+import powerup.systers.com.memory_match_game.MemoryMatchGameActivity;
+import powerup.systers.com.memory_match_game.MemoryMatchSessionManager;
 import powerup.systers.com.minesweeper.MinesweeperGameActivity;
 import powerup.systers.com.minesweeper.MinesweeperSessionManager;
 import powerup.systers.com.powerup.PowerUpUtils;
@@ -40,8 +42,9 @@ public class MapActivity extends Activity {
                     overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                 } else if (new SinkToSwimSessionManager(MapActivity.this).isSinkToSwimOpened()) {
                     startActivity(new Intent(MapActivity.this, SinkToSwimGame.class));
-                } else if (new VocabMatchSessionManager(MapActivity.this).isVocabMatchOpened()) {
-                    startActivity(new Intent(MapActivity.this, VocabMatchGameActivity.class));
+                } else if (new MemoryMatchSessionManager(MapActivity.this).isMemoryMatchOpened()){
+                    startActivity(new Intent(MapActivity.this, MemoryMatchGameActivity.class));
+                    overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                 } else {
                     Intent intent = new Intent(MapActivity.this, ScenarioOverActivity.class);
                     intent.putExtra(PowerUpUtils.SOURCE,PowerUpUtils.MAP);

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -22,6 +22,7 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import powerup.systers.com.datamodel.SessionHistory;
+import powerup.systers.com.memory_match_game.MemoryMatchSessionManager;
 import powerup.systers.com.minesweeper.MinesweeperSessionManager;
 import powerup.systers.com.sink_to_swim_game.SinkToSwimSessionManager;
 import powerup.systers.com.vocab_match_game.VocabMatchSessionManager;
@@ -61,6 +62,8 @@ public class StartActivity extends Activity {
                                 .saveSinkToSwimOpenedStatus(false);
                             new VocabMatchSessionManager(StartActivity.this)
                                 .saveVocabMatchOpenedStatus(false);
+                            new MemoryMatchSessionManager(StartActivity.this)
+                                .saveMemoryMatchOpenedStatus(false);
                             startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
                             overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchEndActivity.java
@@ -34,6 +34,7 @@ public class MemoryMatchEndActivity extends Activity {
 
     @OnClick(R.id.continue_btn_memory)
     public void clickContinue(){
+        new MemoryMatchSessionManager(this).saveMemoryMatchOpenedStatus(false);
         startActivity(new Intent(MemoryMatchEndActivity.this, ScenarioOverActivity.class));
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
@@ -21,8 +21,8 @@ import java.util.Random;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+import powerup.systers.com.MapActivity;
 import powerup.systers.com.R;
-import powerup.systers.com.StartActivity;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.powerup.PowerUpUtils;
 
@@ -100,7 +100,7 @@ public class MemoryMatchGameActivity extends Activity {
                 gameEnd();
             }
         };
-        if(calledByTutorialActivity)
+        if(!calledByTutorialActivity)
             countDownTimer.start();
     }
 
@@ -221,5 +221,12 @@ public class MemoryMatchGameActivity extends Activity {
         countDownTimer = null;
         sessionManager.saveData(score, millisLeft, arrayTile.get(positionCount), arrayTile.get(positionCount - 1) , correctAnswer, wrongAnswer);
         super.onPause();
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        startActivity(new Intent(MemoryMatchGameActivity.this, MapActivity.class));
+        overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }
 }


### PR DESCRIPTION
### Description

In this PR, I have attached session manager to mini-game. The logic here is if the mini game was left in middle it is considered as still open and the value is set accordingly in saveSinkToSwimOpenedStatus(). Additionally, the values of all the variables in onPause().
Now when a scenario is clicked, first it is checked whether the mini-game was saved as open or not using isSinkToSwimOpened(). If it was opened first the mini-game is launched and all the variables are set according to the values stored in shared preferences.

Fixes #1252

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

The functionality can be tested by leaving the mini game in the middle and then pressing home or school on map again.

![videotogif_2018 07 18_23 44 46](https://user-images.githubusercontent.com/26908195/42900370-62bf2f76-8ae6-11e8-9ca7-dc5ce9a9d0e8.gif)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
