### PR TITLE
Attached session manager to Save Blood

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/GameLevel2Activity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/GameLevel2Activity.java
@@ -38,6 +38,8 @@ import powerup.systers.com.kill_the_virus_game.KillTheVirusGame;
 import powerup.systers.com.kill_the_virus_game.KillTheVirusSessionManager;
 import powerup.systers.com.kill_the_virus_game.KillTheVirusTutorials;
 import powerup.systers.com.powerup.PowerUpUtils;
+import powerup.systers.com.save_the_blood_game.SaveTheBloodGameActivity;
+import powerup.systers.com.save_the_blood_game.SaveTheBloodSessionManager;
 import powerup.systers.com.save_the_blood_game.SaveTheBloodTutorialActivity;
 import powerup.systers.com.vocab_match_game.VocabMatchTutorials;
 
@@ -89,6 +91,10 @@ public class GameLevel2Activity extends Activity {
 
         if(new KillTheVirusSessionManager(this).isKillTheVirusOpened()){
             startActivity(new Intent(GameLevel2Activity.this, KillTheVirusGame.class));
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+        }
+        if(new SaveTheBloodSessionManager(this).isSaveBloodOpened()){
+            startActivity(new Intent(GameLevel2Activity.this, SaveTheBloodGameActivity.class));
             overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
         }
 
@@ -266,6 +272,7 @@ public class GameLevel2Activity extends Activity {
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
             } else if (type == -11) {
                 startActivity(new Intent(GameLevel2Activity.this, SaveTheBloodTutorialActivity.class));
+                new SaveTheBloodSessionManager(this).saveSaveBloodOpenedStatus(true);
                 overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
             }
         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/MapLevel2Activity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/MapLevel2Activity.java
@@ -22,6 +22,8 @@ import powerup.systers.com.db.DatabaseHandler;
 import powerup.systers.com.kill_the_virus_game.KillTheVirusGame;
 import powerup.systers.com.kill_the_virus_game.KillTheVirusSessionManager;
 import powerup.systers.com.powerup.PowerUpUtils;
+import powerup.systers.com.save_the_blood_game.SaveTheBloodGameActivity;
+import powerup.systers.com.save_the_blood_game.SaveTheBloodSessionManager;
 
 public class MapLevel2Activity extends Activity {
 
@@ -53,6 +55,9 @@ public class MapLevel2Activity extends Activity {
                     overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                 } else if(new KillTheVirusSessionManager(MapLevel2Activity.this).isKillTheVirusOpened()){
                     startActivity(new Intent(MapLevel2Activity.this, KillTheVirusGame.class));
+                    overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+                } else if(new SaveTheBloodSessionManager(MapLevel2Activity.this).isSaveBloodOpened()){
+                    startActivity(new Intent(MapLevel2Activity.this, SaveTheBloodGameActivity.class));
                     overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                 } else {
                     Intent intent = new Intent(MapLevel2Activity.this, ScenarioOverLevel2Activity.class);

--- a/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/StartActivity.java
@@ -24,6 +24,7 @@ import android.widget.Toast;
 import powerup.systers.com.datamodel.SessionHistory;
 import powerup.systers.com.kill_the_virus_game.KillTheVirusSessionManager;
 import powerup.systers.com.minesweeper.MinesweeperSessionManager;
+import powerup.systers.com.save_the_blood_game.SaveTheBloodSessionManager;
 import powerup.systers.com.sink_to_swim_game.SinkToSwimSessionManager;
 import powerup.systers.com.vocab_match_game.VocabMatchSessionManager;
 
@@ -64,6 +65,8 @@ public class StartActivity extends Activity {
                                 .saveVocabMatchOpenedStatus(false);
                             new KillTheVirusSessionManager(StartActivity.this)
                                     .saveKillTheVirusOpenedStatus(false);
+                            new SaveTheBloodSessionManager(StartActivity.this)
+                                    .saveSaveBloodOpenedStatus(false);
                             startActivityForResult(new Intent(StartActivity.this, AvatarRoomActivity.class), 0);
                             overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                         }

--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodEndActivity.java
@@ -36,6 +36,7 @@ public class SaveTheBloodEndActivity extends Activity {
     public void clickContinue(){
         Intent intent = new Intent(SaveTheBloodEndActivity.this, ScenarioOverLevel2Activity.class);
         intent.putExtra(PowerUpUtils.IS_FINAL_SCENARIO_EXTRA, true);
+        new SaveTheBloodSessionManager(this).saveSaveBloodOpenedStatus(false);
         startActivity(intent);
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodGameActivity.java
@@ -75,6 +75,19 @@ public class SaveTheBloodGameActivity extends Activity {
 
     //Setting up the initial state of elements
     public void initializeViews() {
+        boolean calledByTutorial = getIntent().
+                getBooleanExtra(PowerUpUtils.CALLED_BY, false);
+        if(!calledByTutorial){
+            SaveTheBloodSessionManager sessionManager = new SaveTheBloodSessionManager(this);
+            score = sessionManager.getCurrScore();
+            millisLeft = sessionManager.getTimeLeft();
+            count = sessionManager.getCurrRound();
+            correctAnswer = sessionManager.getCorrectAnswer();
+            wrongAnswer = sessionManager.getWrongAnswer();
+            progress = sessionManager.getCurrentProgress();
+            txtScore.setText(""+score);
+            roundCount = count + 1;
+            }
         progressBar.setProgress(progress);
         countDownTimer.start();
         txtSituation.setText(PowerUpUtils.TXT_QUES_ANS_SAVE_BLOOD[count][0]);

--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodTutorialActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodTutorialActivity.java
@@ -12,6 +12,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.R;
+import powerup.systers.com.powerup.PowerUpUtils;
 
 public class SaveTheBloodTutorialActivity extends Activity {
 
@@ -76,7 +77,9 @@ public class SaveTheBloodTutorialActivity extends Activity {
         else if(tutorialCount == 2)
             showTutorial3();
         else {
-            startActivity(new Intent(SaveTheBloodTutorialActivity.this, SaveTheBloodGameActivity.class));
+            Intent intent = new Intent(SaveTheBloodTutorialActivity.this,SaveTheBloodGameActivity.class)
+                    .putExtra(PowerUpUtils.CALLED_BY, true);
+            startActivity(intent);
             overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
         }
     }


### PR DESCRIPTION
### Description

In this PR, I have attached session manager to mini-game. The logic here is if the mini game was left in middle it is considered as still open and the value is set accordingly in saveSaveBloodOpenedStatus(). Additionally, the values of all the variables in onPause().
Now when a scenario is clicked, first it is checked whether the mini-game was saved as open or not using isSaveBloodOpened(). If it was opened first the mini-game is launched and all the variables are set according to the values stored in shared preferences.

Fixes #1257 

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

The functionality can be tested by leaving the mini game in the middle and then pressing library on map again.

![videotogif_2018 07 20_01 34 40](https://user-images.githubusercontent.com/26908195/42967823-13108ebe-8bbf-11e8-9c73-575c4520a492.gif)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
