### PR TITLE
Fixed to populate scenarios with correct dialogues

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen/ScenarioOverActivity.java
@@ -223,6 +223,8 @@ public class ScenarioOverActivity extends AppCompatActivity implements ScenarioO
     @Override
     public void setCurrentScenario(Scenario scenario) {
         scene = scenario;
+        if(scene != null)
+            SessionHistory.currQID = scene.getFirstQuestionID();
     }
 
     @Override


### PR DESCRIPTION
### Description
The mapping of dialogues was incorrect because the value of SessionHistory.currQID was updated and overwritten in GameActivity because of trigerring of overridden metods.
A better way to ensure proper value of SessionHistory.currQID would be to update it in ScenarioOverActivity .

Fixes #1264 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

![screenshot_2018-07-24-18-34-51-107_powerup systers com powerup](https://user-images.githubusercontent.com/26908195/43143843-6bd6b18c-8f79-11e8-9288-d69223815395.png)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
