### PR TITLE
Rectified behaviour of LOAD Game

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/data/SessionHistory.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/data/SessionHistory.java
@@ -23,6 +23,7 @@ public class SessionHistory {
     public static boolean sceneHospitalLevel2IsReplayed = false;
     public static boolean sceneLibraryLevel2IsReplayed = false;
     public static boolean hasPreviouslyCustomized = false;
+    public static boolean level1Completed = false;
     public static int[] npcList;
     public static boolean adult1Chosen = false;
     public static boolean adult2Chosen = false;

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/StartActivity.java
@@ -29,6 +29,7 @@ import powerup.systers.com.minesweeper.MinesweeperSessionManager;
 import powerup.systers.com.sink_to_swim_game.SinkToSwimSessionManager;
 import powerup.systers.com.ui.avatar_room.AvatarRoomActivity;
 import powerup.systers.com.ui.map_screen.MapActivity;
+import powerup.systers.com.ui.map_screen_level2.MapLevel2Activity;
 import powerup.systers.com.utils.InjectionClass;
 import powerup.systers.com.vocab_match_game.VocabMatchSessionManager;
 
@@ -57,8 +58,8 @@ public class StartActivity extends Activity {
 
         // populate database if it's first run of application
         if (hasPreviouslyStarted) {
-             populateDatabase();
-             dataSource.setFirstTime(false);
+            populateDatabase();
+            dataSource.setFirstTime(false);
         }
     }
 
@@ -122,28 +123,32 @@ public class StartActivity extends Activity {
 
     @OnClick(R.id.startButtonMain)
     public void startButtonListener(View view) {
-            if (dataSource.checkPreviouslyCustomized()) {
-                // load map activity if shared preferences return true
+        // load map activity if shared preferences return true
+        if (dataSource.checkPreviouslyCustomized()) {
+            //load Level 2 if Level 2 is complete
+            if (SessionHistory.level1Completed)
+                startActivity(new Intent(context, MapLevel2Activity.class));
+            else
                 startActivity(new Intent(context, MapActivity.class));
-                overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
-            } else {
-                // create dialog to use new game button instead & dismiss dialog
-                AlertDialog.Builder builder = new AlertDialog.Builder(StartActivity.this);
-                builder.setTitle(context.getResources().getString(R.string.start_title_message_load))
-                        .setMessage(getResources().getString(R.string.start_dialog_message_load));
-                builder.setPositiveButton(getString(R.string.start_confirm_message_load),
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+        } else {
+            // create dialog to use new game button instead & dismiss dialog
+            AlertDialog.Builder builder = new AlertDialog.Builder(StartActivity.this);
+            builder.setTitle(context.getResources().getString(R.string.start_title_message_load))
+                    .setMessage(getResources().getString(R.string.start_dialog_message_load));
+            builder.setPositiveButton(getString(R.string.start_confirm_message_load),
                     new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        dialog.dismiss();
-                    }
-                });
+                        public void onClick(DialogInterface dialog, int id) {
+                            dialog.dismiss();
+                        }
+                    });
 
-                AlertDialog dialog = builder.create();
-                ColorDrawable drawable = new ColorDrawable(Color.WHITE);
-                drawable.setAlpha(200);
-                dialog.getWindow().setBackgroundDrawable(drawable);
-                dialog.show();
-            }
+            AlertDialog dialog = builder.create();
+            ColorDrawable drawable = new ColorDrawable(Color.WHITE);
+            drawable.setAlpha(200);
+            dialog.getWindow().setBackgroundDrawable(drawable);
+            dialog.show();
+        }
     }
 
     private void populateDatabase() {

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/final_avatar_room/FinalAvatarActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/final_avatar_room/FinalAvatarActivity.java
@@ -90,6 +90,7 @@ public class FinalAvatarActivity extends Activity implements FinalAvatarRoomCont
         SessionHistory.progressInvisibility = 0;
         SessionHistory.progressHealing = 0;
         SessionHistory.progressHealth = 0;
+        SessionHistory.level1Completed = false;
         // starting map activity
         startActivityForResult(new Intent(FinalAvatarActivity.this, PreGameSetupInitialActivity.class), 0);
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen/ScenarioOverActivity.java
@@ -91,6 +91,7 @@ public class ScenarioOverActivity extends AppCompatActivity implements ScenarioO
             public void onClick(View v) {
                 new GameActivity().gameActivityInstance.finish();
                 if (getIntent().getBooleanExtra(PowerUpUtils.IS_FINAL_SCENARIO_EXTRA, false)) {
+                    SessionHistory.level1Completed = true;
                     startActivity(new Intent(ScenarioOverActivity.this, Level2TransitionActivity.class));
                     overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
                 } else {

--- a/PowerUp/app/src/main/java/powerup/systers/com/utils/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/utils/PowerUpUtils.java
@@ -325,7 +325,6 @@ public class PowerUpUtils {
     };
     public static volatile boolean sPauseTest = true;
 
-
     public static String TXT_QUES_ANS_SAVE_BLOOD[][] = { {"Presented Situation 1", "Answer = Correct", "Answer = Correct", "Answer = Wrong", "Answer = Wrong","Answer = Neutral","Answer = Neutral"},
             {"Presented Situation 2", "Answer = Wrong", "Answer = Correct", "Answer = Neutral", "Answer = Wrong","Answer = Correct","Answer = Neutral"},
             {"Presented Situation 3", "Answer = Neutral", "Answer = Neutral", "Answer = Correct", "Answer = Correct","Answer = Wrong","Answer = Wrong"},


### PR DESCRIPTION
### Description
In this PR I have fixed the behavior of LOAD button such that it launches Level 2 once level 1 is complete.
A static boolean variable is used in PowerUpUtils.java, level1Complete, that is initially set to false. It sets to true once Level 1 is completed. Now when LOAD GAME button is pressed on Start activity the value of the variable is checked first and Level 1 or Level 2 is launched accordingly.

Fixes #1287 

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Steps to reproduce:
1. Complete Level 1 and go to map for Level 2
2. Press the home button on the Map screen and go the start screen
3.  Press the LOAD Game Button
It now launches Map screen of Level 2


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] Any dependent changes have been published in downstream modules
