### PR TITLE
Fixed the ending case for  save blood

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodEndActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/save_the_blood_game/SaveTheBloodEndActivity.java
@@ -35,6 +35,7 @@ public class SaveTheBloodEndActivity extends Activity {
 
     @OnClick(R.id.btn_continue_save_blood)
     public void clickContinue(){
+        new SaveTheBloodSessionManager(this).saveSaveBloodOpenedStatus(false);
         Intent intent = new Intent(SaveTheBloodEndActivity.this, ScenarioOverLevel2Activity.class);
         intent.putExtra(PowerUpUtils.IS_FINAL_SCENARIO_EXTRA, true);
         startActivity(intent);

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/game_activity_level2/GameLevel2Activity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/game_activity_level2/GameLevel2Activity.java
@@ -465,7 +465,7 @@ public class GameLevel2Activity extends Activity implements GameScreenLevel2Cont
 
     @Override
     public void setScenarioBackground(int id) {
-        findViewById(R.id.root).setBackground(getResources().getDrawable(PowerUpUtils.SCENARIO_BACKGROUNDS[id - 4]));
+        findViewById(R.id.root).setBackground(getResources().getDrawable(PowerUpUtils.SCENARIO_BACKGROUNDS[id]));
     }
 
     @Override

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen_level2/ScenarioOverLevel2Activity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen_level2/ScenarioOverLevel2Activity.java
@@ -124,19 +124,19 @@ public class ScenarioOverLevel2Activity extends AppCompatActivity implements Sce
             String scenario = getIntent().getStringExtra(PowerUpUtils.SCENARIO_NAME);
             int id;
             switch (scenario) {
-                case "Home":
+                case "Home Level 2":
                     id = 4;
                     SessionHistory.sceneHomeIsReplayed = true;
                     break;
-                case "School":
+                case "School Level 2":
                     id = 5;
                     SessionHistory.sceneSchoolIsReplayed = true;
                     break;
-                case "Hospital":
+                case "Hospital Level 2":
                     id = 6;
                     SessionHistory.sceneHospitalIsReplayed = true;
                     break;
-                case "Library":
+                case "Library Level 2":
                     id = 7;
                     SessionHistory.sceneLibraryIsReplayed = true;
                     break;

--- a/PowerUp/app/src/main/java/powerup/systers/com/utils/PowerUpUtils.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/utils/PowerUpUtils.java
@@ -59,7 +59,7 @@ public class PowerUpUtils {
             {"Round 3 Pro 1 ", "Round 3 Pro 2", "Round 3 Con 1"}};
     public static final String[][] SWIM_SINK_QUESTION_ANSWERS = {{"Test Ques 1: \n Answer=F", "F"}, {"Test Ques 2: \n Answer=T", "T"}, {"Test Ques 3: \n Answer=T", "T"}, {"Test Ques 4: \n Answer=F", "F"}, {"Test Ques 5: \n Answer=F", "F"}};
     public static final int[] SWIM_TUTS = {R.drawable.swim_tut1, R.drawable.swim_tut2, R.drawable.swim_tut3};
-    public static final int[] SCENARIO_BACKGROUNDS = {R.drawable.background, R.drawable.background, R.drawable.background, R.drawable.home_bg, R.drawable.classroom, R.drawable.hospital_bg, R.drawable.library};
+    public static final int[] SCENARIO_BACKGROUNDS = {R.drawable.background, R.drawable.background, R.drawable.background, R.drawable.home_bg, R.drawable.classroom, R.drawable.hospital_bg, R.drawable.library, R.drawable.home_bg, R.drawable.classroom, R.drawable.hospital_bg, R.drawable.library};
     public static final int[] VOCAB_TILES_IMAGES = {R.drawable.vocab_tile1, R.drawable.vocab_tile2, R.drawable.vocab_tile3, R.drawable.vocab_cramping_tile, R.drawable.vocab_deo_tile, R.drawable.vocab_depression_tile, R.drawable.vocab_fat, R.drawable.vocab_skinny, R.drawable.vocab_tampon};
     public static final String[] VOCAB_MATCHES_BOARDS_TEXTS = {"Periods", "Pimples", "Bra", "Cramping", "Deo", "Depression", "Fat", "Skinny", "Tampon"};
     public static final int[] VOCAB_MATCH_TUTS = {R.drawable.vocab_tut1, R.drawable.vocab_tut2};


### PR DESCRIPTION
### Description
The error was in SaveTheBloodEndActivity where the variable OpenedStatus was not reset to false
While fixing this issue, I came across another problem. 
Once all the scenes in Level 2 are played, no matter which scene is chosen for replay, the home scenario was launched always. The problem was in switch case block inside the click listener for replay button. I fixed this as well

Fixes #1295 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Steps to reproduce:
1. Complete the save the blood game
2. Launch map again from the game over screen
3. Choose any scenario to replay
The selected scenario will be replayed whereas initially Save Blood game was always launched.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] Any dependent changes have been published in downstream modules
