### PR TITLE
Restoring the points when app is reloaded

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/data/dao/PointsDao.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/data/dao/PointsDao.java
@@ -2,12 +2,17 @@ package powerup.systers.com.data.dao;
 
 import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Insert;
+import android.arch.persistence.room.OnConflictStrategy;
+import android.arch.persistence.room.Query;
 
 import powerup.systers.com.data.entities.Points;
 
 @Dao
 public interface PointsDao {
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insertPoints(Points points);
+
+    @Query("SELECT * FROM Point")
+    Points getPoints();
 }

--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
@@ -2,6 +2,7 @@ package powerup.systers.com.memory_match_game;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.arch.persistence.room.Room;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.CountDownTimer;
@@ -23,7 +24,9 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.R;
+import powerup.systers.com.data.AppDatabase;
 import powerup.systers.com.data.SessionHistory;
+import powerup.systers.com.data.entities.Points;
 import powerup.systers.com.ui.map_screen.MapActivity;
 import powerup.systers.com.utils.PowerUpUtils;
 
@@ -52,11 +55,19 @@ public class MemoryMatchGameActivity extends Activity {
     public boolean calledFromActivity = true, correctAns = true, buttonClick = false;;
     private long millisLeft = 30000;
 
+    private AppDatabase database;
+
     @SuppressLint("ResourceType")
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_memory_match_game);
+
+        //Initializing the database
+        database = Room.databaseBuilder(getApplicationContext(),AppDatabase.class,"points-database")
+                .allowMainThreadQueries()
+                .build();
+
         ButterKnife.bind(this);
         translateTile = AnimationUtils.loadAnimation(this, R.animator.translate_tile);
         random = new Random();
@@ -221,6 +232,11 @@ public class MemoryMatchGameActivity extends Activity {
         //Adding mini-game scores
         SessionHistory.totalPoints += score;
         SessionHistory.currScenePoints += score;
+
+        //Storing points in Room database
+        Points p = new Points(1,SessionHistory.progressHealth,SessionHistory.progressInvisibility,SessionHistory.progressHealing,SessionHistory.progressTelepathy,SessionHistory.totalPoints);
+        database.pointsDao().insertPoints(p);
+
         startActivity(intent);
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen/ScenarioOverActivity.java
@@ -8,6 +8,7 @@ package powerup.systers.com.ui.scenario_over_screen;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.arch.persistence.room.Room;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -31,7 +32,9 @@ import android.widget.TextView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.R;
+import powerup.systers.com.data.AppDatabase;
 import powerup.systers.com.data.DataSource;
+import powerup.systers.com.data.entities.Points;
 import powerup.systers.com.data.entities.Scenario;
 import powerup.systers.com.data.SessionHistory;
 import powerup.systers.com.ui.Level2TransitionActivity;
@@ -70,6 +73,12 @@ public class ScenarioOverActivity extends AppCompatActivity implements ScenarioO
 
         dataSource = InjectionClass.provideDataSource(scenarioOverActivityInstance);
         setContentView(R.layout.activity_scenario_over);
+
+        //Initializing the database
+        AppDatabase database = Room.databaseBuilder(getApplicationContext(),AppDatabase.class,"points-database")
+                .allowMainThreadQueries()
+                .build();
+
         ButterKnife.bind(this);
         presenter = new ScenarioOverPresenter(this, dataSource);
 
@@ -86,6 +95,11 @@ public class ScenarioOverActivity extends AppCompatActivity implements ScenarioO
         TextView karmaPoints = findViewById(R.id.karmaPoints);
 
         karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+
+        //Storing points in Room database
+        Points p = new Points(1,SessionHistory.progressHealth,SessionHistory.progressInvisibility,SessionHistory.progressHealing,SessionHistory.progressTelepathy,SessionHistory.totalPoints);
+        database.pointsDao().insertPoints(p);
+
         continueButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/store_screen/StoreActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/store_screen/StoreActivity.java
@@ -1,6 +1,7 @@
 package powerup.systers.com.ui.store_screen;
 
 import android.annotation.TargetApi;
+import android.arch.persistence.room.Room;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -25,10 +26,12 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import powerup.systers.com.R;
+import powerup.systers.com.data.AppDatabase;
 import powerup.systers.com.data.DataSource;
 import powerup.systers.com.data.IDataSource;
 import powerup.systers.com.data.SessionHistory;
 import powerup.systers.com.data.StoreItem;
+import powerup.systers.com.data.entities.Points;
 import powerup.systers.com.ui.map_screen.MapActivity;
 import powerup.systers.com.utils.InjectionClass;
 
@@ -50,6 +53,9 @@ public class StoreActivity extends AppCompatActivity implements StoreContract.IS
 
     private DataSource dataSource;
     private StorePresenter presenter;
+
+    private AppDatabase database;
+    private int points;
 
     @BindView(R.id.karma_points)
     public TextView karmaPoints;
@@ -75,6 +81,12 @@ public class StoreActivity extends AppCompatActivity implements StoreContract.IS
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_store);
+
+        //Initializing the database
+        database = Room.databaseBuilder(getApplicationContext(),AppDatabase.class,"points-database")
+                .allowMainThreadQueries()
+                .build();
+
         ButterKnife.bind(this);
         init();
 
@@ -121,8 +133,16 @@ public class StoreActivity extends AppCompatActivity implements StoreContract.IS
         screenWidth = getResources().getDisplayMetrics().widthPixels;
         screenHeight = getResources().getDisplayMetrics().heightPixels;
 
-        // set the karma points
-        karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+        //get the karma points
+        if(database.pointsDao()!= null){
+            Points p = database.pointsDao().getPoints();
+            points = p.getUserPoints();
+            karmaPoints.setText(String.valueOf(points));
+        }
+        else{
+            karmaPoints.setText(String.valueOf(SessionHistory.totalPoints));
+        }
+
         presenter.setValues();
         // create store data arraylist & add it in allDataSet array list
         allDataSet = presenter.createDataList();


### PR DESCRIPTION
### Description
The points are restored even after the user removes the app from the background. However this functionality has been implemented for the specific case when the user exits the app after the Memory Match Game. 
Please review the PR and if everything looks fine I'll proceed to implement the feature for other cases too.

Fixes #1317 

### Type of Change:

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
I have tested the app on my Android device. Relevant GIF is provided as below.
![ezgif com-optimize 5](https://user-images.githubusercontent.com/32400008/50655034-d430ab00-0fb4-11e9-8cba-fc21e17f7400.gif)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
