### PR TITLE
Fixed issue of timer freezing in Memory Match #1325

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
@@ -52,6 +52,9 @@ public class MemoryMatchGameActivity extends Activity {
     public boolean calledFromActivity = true, correctAns = true, buttonClick = false;;
     private long millisLeft = 30000;
 
+    //Variable to see if game has paused and restarted
+    private static boolean restart=false;
+
     @SuppressLint("ResourceType")
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -60,6 +63,7 @@ public class MemoryMatchGameActivity extends Activity {
         ButterKnife.bind(this);
         translateTile = AnimationUtils.loadAnimation(this, R.animator.translate_tile);
         random = new Random();
+        restart=false;
         initializeView();
     }
 
@@ -67,7 +71,7 @@ public class MemoryMatchGameActivity extends Activity {
         arrayTile = new ArrayList<>();
         boolean calledByTutorialActivity = getIntent().getBooleanExtra(PowerUpUtils.CALLED_BY, false);
 
-        if(!calledByTutorialActivity){
+        if(!calledByTutorialActivity || restart) {
             MemoryMatchSessionManager sessionManager = new MemoryMatchSessionManager(this);
             score = sessionManager.getCurrScore();
             millisLeft = sessionManager.getTimeLeft();
@@ -101,7 +105,7 @@ public class MemoryMatchGameActivity extends Activity {
                 gameEnd();
             }
         };
-        if(!calledByTutorialActivity)
+        if(!calledByTutorialActivity || restart)
             countDownTimer.start();
     }
 
@@ -255,5 +259,12 @@ public class MemoryMatchGameActivity extends Activity {
         super.onBackPressed();
         startActivity(new Intent(MemoryMatchGameActivity.this, MapActivity.class));
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+    }
+
+    public void onRestart() {
+        super.onRestart();
+        //Set Restart value to true once game paused and resumed
+        restart=true;
+        initializeView();
     }
 }


### PR DESCRIPTION
### Description
Fixed the cause of timer stopping when home button pressed and game resumed by adding onRestart() method.

Fixes # 1325

### Type of Change:
**Delete irrelevant options.**

- Code
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested it on various possible scenarios and the app performed as expected.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules


![20190129002125720x14400](https://user-images.githubusercontent.com/42450012/51862046-bfe98f00-2363-11e9-96e0-3628e179cf1a.gif)
