### PR TITLE
Fixes issue #697. Text is now visible properly in Vocab Match Game.

### DIFF
--- a/PowerUp/app/src/main/res/layout/activity_vocab_match_game.xml
+++ b/PowerUp/app/src/main/res/layout/activity_vocab_match_game.xml
@@ -60,7 +60,7 @@
                android:background="@drawable/vocab_clipboard_yellow"
                android:text="@string/pimples"
                android:gravity="center"
-               />
+               android:paddingLeft="@dimen/vocab_match_padding"/>
             <powerup.systers.com.vocab_match_game.VocabBoardTextView
                 android:id="@+id/tv2"
                 android:layout_width="match_parent"
@@ -68,7 +68,8 @@
                 android:layout_weight="1"
                 android:background="@drawable/vocab_clipboard_yellow"
                 android:text="@string/bra"
-                android:gravity="center"/>
+                android:gravity="center"
+                android:paddingLeft="@dimen/vocab_match_padding"/>
             <powerup.systers.com.vocab_match_game.VocabBoardTextView
                 android:id="@+id/tv3"
                 android:layout_width="match_parent"
@@ -76,7 +77,8 @@
                 android:layout_weight="1"
                 android:background="@drawable/vocab_clipboard_yellow"
                 android:text="@string/periods"
-                android:gravity="center"/>
+                android:gravity="center"
+                android:paddingLeft="@dimen/vocab_match_padding"/>
         </LinearLayout>
     </LinearLayout>
 

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -65,4 +65,5 @@
     <dimen name="margin_right_txt_msg2">125dp</dimen>
     <dimen name="btn_padding">4dp</dimen>
     <dimen name="btn_radius">3dp</dimen>
+    <dimen name="vocab_match_padding">35dp</dimen>
 </resources>


### PR DESCRIPTION
### Description
I have made changes in the activity_vocab_match_game.xml file. I have simply added padding value to keep the text at the centre of the image

Fixes #697 

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface
- Outreach
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
I have tested this on two android devices(vivo y51l and micromax HS2) and it works perfectly fine


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
![WhatsApp Image 2020-02-22 at 11 59 28 PM](https://user-images.githubusercontent.com/51824493/75097339-a864f000-55cf-11ea-9ed3-1f9597a2fa04.jpeg)
![WhatsApp Image 2020-02-22 at 11 59 29 PM](https://user-images.githubusercontent.com/51824493/75097340-aac74a00-55cf-11ea-9ac4-8d283679d5e2.jpeg)
