### PR TITLE
Fixed replay Button(Now the question won't be updated to next's level…

### DIFF
--- a/PowerUp/app/build.gradle
+++ b/PowerUp/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
     defaultConfig {
-        applicationId "powerup.systers.com.powerup"
+        applicationId "powerup.systers.com"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/map_screen/MapActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/map_screen/MapActivity.java
@@ -72,6 +72,14 @@ public class MapActivity extends Activity implements MapContract.IMapView{
         //setup for activity
         init();
 
+        if(getIntent().getExtras() != null && getIntent().getExtras().getInt(String.valueOf(R.string.corrected_replay))==1){
+            Intent intent = new Intent(MapActivity.this, ScenarioOverActivity.class);
+            intent.putExtra(String.valueOf(R.string.corrected_replay), 1);
+            startActivity(intent);
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+
+        }
+
         // initialize presneter
         MapPresenter presenter = new MapPresenter(dataSource, this);
 

--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen/ScenarioOverActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/scenario_over_screen/ScenarioOverActivity.java
@@ -47,6 +47,7 @@ public class ScenarioOverActivity extends AppCompatActivity implements ScenarioO
     public static int scenarioActivityDone;
     private DataSource dataSource;
     public Scenario scene, prevScene;
+    public int flag;
 
     //Todo check preferences and shift it to pref file
     private final String PREF_NAME_SCENARIO = "SCENARIO_OVER_DIALOG";
@@ -105,6 +106,12 @@ public class ScenarioOverActivity extends AppCompatActivity implements ScenarioO
             continueButton.setOnClickListener(null);
         }
 
+        if(getIntent().getExtras()!=null && getIntent().getExtras().getInt(String.valueOf(R.string.corrected_replay))==1) {
+            startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+
+
+        }
     }
 
     private void init() {
@@ -149,6 +156,7 @@ public class ScenarioOverActivity extends AppCompatActivity implements ScenarioO
         } else {
             SessionHistory.currSessionID = SessionHistory.prevSessionID;
             scenarioActivityDone = 0;
+            flag=1;
         }                //Check that reducing points does not lead to negetive value
         if(SessionHistory.totalPoints - SessionHistory.currScenePoints >= 0)
             SessionHistory.totalPoints -= SessionHistory.currScenePoints;
@@ -157,8 +165,16 @@ public class ScenarioOverActivity extends AppCompatActivity implements ScenarioO
         dataSource.resetCompleted(SessionHistory.currSessionID);
         dataSource.resetReplayed(SessionHistory.currSessionID);
         scenarioOverActivityInstance.finish();
-        startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
-        overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+        if(flag==1){
+            Intent intent = new Intent(ScenarioOverActivity.this, MapActivity.class);
+            intent.putExtra(String.valueOf(R.string.corrected_replay), flag);
+            startActivity(intent);
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+        }
+        else{
+            startActivity(new Intent(ScenarioOverActivity.this, GameActivity.class));
+            overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
+        }
     }
     /**
      * Goes back to the map when user presses back button

--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <string name="app_name">Power Up</string>
     <string name="action_settings">Settings</string>
+    <string name="corrected_replay">corrected_replayButton</string>
     <string name="house">School</string>
     <string name="boyfriend">Home</string>
     <string name="hospital">Hospital</string>


### PR DESCRIPTION
… questions after replay Button is clicked)

### Description
Fixed the replay button functionality, so that when  a user clicks on replay button after coming from current game, get the question of current scenario and not question of next scenario.
Fixes #1363 

### Type of Change:

- Code
- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
I have tested this on my android device.
![corrected_replay](https://user-images.githubusercontent.com/42201292/75620470-6891a000-5baf-11ea-8362-ea6629c5d794.gif)

![corrected_replay1](https://user-images.githubusercontent.com/42201292/75620525-db028000-5baf-11ea-8e4f-030615164a4d.gif)


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules