### PR TITLE
FIxed #1366 Unwanted behavior when ABOUT button is clicked rapidly.

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/StartActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/StartActivity.java
@@ -38,6 +38,9 @@ public class StartActivity extends Activity {
     @BindView(R.id.startButtonMain)
     public Button startButton;
 
+    @BindView(R.id.aboutButtonMain)
+    public Button aboutButtonMain;
+
     private boolean hasPreviouslyStarted;
     private Context context;
     private DataSource dataSource;
@@ -67,6 +70,7 @@ public class StartActivity extends Activity {
     @OnClick(R.id.aboutButtonMain)
     public void aboutButtonListener(View view) {
         startActivity(new Intent(context, AboutActivity.class));
+        aboutButtonMain.setEnabled(false);
         overridePendingTransition(R.animator.fade_in_custom, R.animator.fade_out_custom);
     }
 
@@ -163,6 +167,7 @@ public class StartActivity extends Activity {
         if (hasPreviouslyStarted) {
             startButton.setText(getString(R.string.resume_text));
         }
+        aboutButtonMain.setEnabled(true);
     }
 
     @Override


### PR DESCRIPTION
### Description
Now the about button works perfectly. When it is clicked, it gets disabled and gets reenabled when onResume method is called for the StartActivity.

Fixes #1366 

### Type of Change:
- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
Tested on my device. Everything works perfectly.


### Checklist:


- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 

