### PR TITLE
Fixed the Back Pressed

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/memory_match_game/MemoryMatchGameActivity.java
@@ -250,7 +250,13 @@ public class MemoryMatchGameActivity extends Activity {
         MemoryMatchSessionManager sessionManager = new MemoryMatchSessionManager(this);
         countDownTimer.cancel();
         countDownTimer = null;
-        sessionManager.saveData(score, millisLeft, arrayTile.get(positionCount), arrayTile.get(positionCount - 1) , correctAnswer, wrongAnswer);
+        try {
+            sessionManager.saveData(score, millisLeft, arrayTile.get(positionCount), arrayTile.get(positionCount - 1), correctAnswer, wrongAnswer);
+        }
+        catch (ArrayIndexOutOfBoundsException e)
+        {
+            Log.d("NODATA",e.toString());
+        }
         super.onPause();
     }
 


### PR DESCRIPTION
### Description
The backpressed in MemoryMatchGameActivity is fixed.
The app does not crash anymore on back press.

Fixes #1370 

### Type of Change:

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
Tested on OnePlus6t



**Code/Quality Assurance Only**
-  My changes generate no new warnings 

