### PR TITLE
Fixes issue #697. Text is now visible properly in vocab match game

### DIFF
--- a/PowerUp/app/src/main/res/layout/activity_vocab_match_game.xml
+++ b/PowerUp/app/src/main/res/layout/activity_vocab_match_game.xml
@@ -60,6 +60,11 @@
                android:background="@drawable/vocab_clipboard_yellow"
                android:text="@string/pimples"
                android:gravity="center"
+               android:autoSizeTextType="uniform"
+               android:autoSizeMinTextSize="@dimen/vocab_match_minTextSize"
+               android:autoSizeMaxTextSize="@dimen/vocab_match_maxTextSize"
+               android:autoSizeStepGranularity="1dp"
+               android:paddingLeft="@dimen/vocab_match_padding"
                />
             <powerup.systers.com.vocab_match_game.VocabBoardTextView
                 android:id="@+id/tv2"
@@ -68,7 +73,12 @@
                 android:layout_weight="1"
                 android:background="@drawable/vocab_clipboard_yellow"
                 android:text="@string/bra"
-                android:gravity="center"/>
+                android:gravity="center"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="@dimen/vocab_match_minTextSize"
+                android:autoSizeMaxTextSize="@dimen/vocab_match_maxTextSize"
+                android:autoSizeStepGranularity="1dp"
+                android:paddingLeft="@dimen/vocab_match_padding"/>
             <powerup.systers.com.vocab_match_game.VocabBoardTextView
                 android:id="@+id/tv3"
                 android:layout_width="match_parent"
@@ -76,9 +86,12 @@
                 android:layout_weight="1"
                 android:background="@drawable/vocab_clipboard_yellow"
                 android:text="@string/periods"
-                android:gravity="center"/>
+                android:gravity="center"
+                android:autoSizeTextType="uniform"
+                android:autoSizeMinTextSize="@dimen/vocab_match_minTextSize"
+                android:autoSizeMaxTextSize="@dimen/vocab_match_maxTextSize"
+                android:autoSizeStepGranularity="1dp"
+                android:paddingLeft="@dimen/vocab_match_padding"/>
         </LinearLayout>
     </LinearLayout>
-
-
 </FrameLayout>

--- a/PowerUp/app/src/main/res/values/dimens.xml
+++ b/PowerUp/app/src/main/res/values/dimens.xml
@@ -65,4 +65,7 @@
     <dimen name="margin_right_txt_msg2">125dp</dimen>
     <dimen name="btn_padding">4dp</dimen>
     <dimen name="btn_radius">3dp</dimen>
+    <dimen name="vocab_match_padding">40dp</dimen>
+    <dimen name="vocab_match_maxTextSize">20dp</dimen>
+    <dimen name="vocab_match_minTextSize">10dp</dimen>
 </resources>


### PR DESCRIPTION
### Description
I have made changes in the activity_vocab_match_game.xml file. I have simply added padding value to keep the text at the centre of the image

Fixes #697 

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
I have tested this on two android devices(vivo y51l and micromax HS2) and it works perfectly fine


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules

![75097340-aac74a00-55cf-11ea-9ac4-8d283679d5e2](https://user-images.githubusercontent.com/51824493/76617758-f9bc2b80-654c-11ea-8815-fbf1dab4bcd8.jpeg)
![75097339-a864f000-55cf-11ea-9ed3-1f9597a2fa04](https://user-images.githubusercontent.com/51824493/76617767-fd4fb280-654c-11ea-8fa8-3e841c14a0f4.jpeg)
