### PR TITLE
Re: Karma points do not add if Ok is not pressed after full power

### DIFF
--- a/PowerUp/app/src/main/java/powerup/systers/com/ui/game_activity/GameActivity.java
+++ b/PowerUp/app/src/main/java/powerup/systers/com/ui/game_activity/GameActivity.java
@@ -317,6 +317,12 @@ public class GameActivity extends Activity implements GameScreenContract.IGameSc
             }
         });
         AlertDialog dialog = builder.create();
+        dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface dialog) {
+                SessionHistory.totalPoints+=5;
+            }
+        });
         ColorDrawable drawable = new ColorDrawable(Color.WHITE);
         drawable.setAlpha(200);
         dialog.getWindow().setBackgroundDrawable(drawable);


### PR DESCRIPTION
### Description
The Karma points add up even when the dialog box is cancelled.

Fixes #1414

### Type of Change:
- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
Tested on OnePlus6t
