### PR TITLE
fix: string hair changed from 'hair' to 'Hair'

### DIFF
--- a/PowerUp/app/src/main/res/values/strings.xml
+++ b/PowerUp/app/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="select_feature">"Choose your feature.."</string>
     <string name="from_activity">"fromActivity"</string>
     <string name="eye">"eyes"</string>
-    <string name="hair">"hair"</string>
+    <string name="hair">"Hair"</string>
     <string name="cloth">"dress_avatar"</string>
     <string name="lowercase_skin">"skin"</string>
     <string name="face">"face"</string>


### PR DESCRIPTION
### Description
String hair has been changed from 'hair' to 'Hair' in strings.xml in avatar_room.

Fixes #1395 

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?
### Before
![bef](https://user-images.githubusercontent.com/54908756/76698631-7117c980-66cb-11ea-8d0b-602047f01a6e.jpg)

### After
![aft1](https://user-images.githubusercontent.com/54908756/76698628-665d3480-66cb-11ea-99ee-0dd83ac0f985.jpg)


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes

